### PR TITLE
docs: Add documentation for swkbd, ac; minor updates for sysapp documentation

### DIFF
--- a/include/coreinit/memorymap.h
+++ b/include/coreinit/memorymap.h
@@ -188,3 +188,5 @@ OSGetDataPhysAddrRange(uint32_t *outPhysicalAddress,
 #ifdef __cplusplus
 }
 #endif
+
+/** @} */

--- a/include/nn/ac.h
+++ b/include/nn/ac.h
@@ -2,6 +2,8 @@
 
 /**
  * \defgroup nn_ac nn_ac
+ * Auto Connect API, used for managing and connecting to internet connection
+ * profiles.
  */
 
 #include <nn/ac/ac_c.h>

--- a/include/nn/ac/ac_c.h
+++ b/include/nn/ac/ac_c.h
@@ -5,6 +5,7 @@
 /**
  * \defgroup nn_ac_c Auto Connect C API
  * \ingroup nn_ac
+ * C functions for the Auto Connect API
  * @{
  */
 
@@ -12,20 +13,77 @@
 extern "C" {
 #endif
 
+/**
+ * An ID number representing a network configuration. These are the same IDs as
+ * shown in System Settings' Connection List.
+ */
 typedef uint32_t ACConfigId;
 
+/**
+ * Initialise the Auto Connect library. Call this function before any other AC
+ * functions.
+ *
+ * \return
+ * A \link nn_result Result\endlink - see \link NNResult_IsSuccess \endlink
+ * and \link NNResult_IsFailure \endlink.
+ *
+ * \sa
+ * - \link ACFinalize \endlink
+ */
 NNResult
 ACInitialize();
 
+/**
+ * Cleanup the Auto Connect library. Do not call any AC functions (other than
+ * \link ACInitialize \endlink) after calling this function.
+ *
+ * \sa
+ * - \link ACInitialize \endlink
+ */
 void
 ACFinalize();
 
+/**
+ * Gets the default connection configuration id. This is the default as marked
+ * in System Settings.
+ *
+ * \param configId
+ * A pointer to an \link ACConfigId \endlink to write the config ID to. Must not
+ * be \c NULL.
+ *
+ * \return
+ * A \link nn_result Result\endlink - see \link NNResult_IsSuccess \endlink
+ * and \link NNResult_IsFailure \endlink.
+ */
 NNResult
 ACGetStartupId(ACConfigId *configId);
 
+/**
+ * Connects to a network, using the configuration represented by the given
+ * \link ACConfigId \endlink.
+ *
+ * \param configId
+ * The \link ACConfigId \endlink representing the network to connect to.
+ *
+ * \return
+ * A \link nn_result Result\endlink - see \link NNResult_IsSuccess \endlink
+ * and \link NNResult_IsFailure \endlink.
+ */
 NNResult
 ACConnectWithConfigId(ACConfigId configId);
 
+/**
+ * Gets the IP address assosciated with the currently active connection.
+ *
+ * \param ip
+ * A pointer to write the IP address to, in
+ * <a href="https://en.wikipedia.org/wiki/IPv4#Address_representations"
+ * target="_blank">numerical</a> form.
+ *
+ * \return
+ * A \link nn_result Result\endlink - see \link NNResult_IsSuccess \endlink
+ * and \link NNResult_IsFailure \endlink.
+ */
 NNResult
 ACGetAssignedAddress(uint32_t *ip);
 

--- a/include/nn/ac/ac_cpp.h
+++ b/include/nn/ac/ac_cpp.h
@@ -5,6 +5,7 @@
 /**
  * \defgroup nn_ac_cpp Auto Connect C++ API
  * \ingroup nn_ac
+ * C++ functions for the Auto Connect API (see nn::ac)
  * @{
  */
 
@@ -12,11 +13,24 @@
 
 namespace nn
 {
+/**
+ * Auto Connect API, used for managing and connecting to internet connection
+ * profiles.
+ */
 namespace ac
 {
 
+/**
+ * An ID number representing a network configuration. These are the same IDs as
+ * shown in System Settings' Connection List.
+ */
 typedef uint32_t ConfigIdNum;
 
+/**
+ * C++ linkage for the autoconnect API, see \link nn::ac \endlink for use.
+ * Cafe provides mangled symbols for C++ APIs, so nn::ac is actually static
+ * inline calls to the mangled symbols under nn::ac::detail.
+ */
 namespace detail
 {
 extern "C"
@@ -31,9 +45,16 @@ nn::Result GetAssignedAddress__Q2_2nn2acFPUl(uint32_t *ip);
 } // extern "C"
 } // namespace detail
 
-
 /**
- * Initialise the nn_ac library.
+ * Initialise the Auto Connect library. Call this function before any other nn::ac
+ * functions.
+ *
+ * \return
+ * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
+ * and \link nn::Result::IsFailure \endlink.
+ *
+ * \sa
+ * - \link Finalize \endlink
  */
 static inline nn::Result
 Initialize()
@@ -41,9 +62,12 @@ Initialize()
    return detail::Initialize__Q2_2nn2acFv();
 }
 
-
 /**
- * Finalise the nn_ac library.
+ * Cleanup the Auto Connect library. Do not call any nn::ac functions (other
+ * than \link Initialize \endlink) after calling this function.
+ *
+ * \sa
+ * - \link Initialize \endlink
  */
 static inline void
 Finalize()
@@ -53,7 +77,16 @@ Finalize()
 
 
 /**
- * Get the default connection configuration id.
+ * Gets the default connection configuration id. This is the default as marked
+ * in System Settings.
+ *
+ * \param id
+ * A pointer to an \link ConfigIdNum \endlink to write the config ID to. Must
+ * not be a \c nullptr.
+ *
+ * \return
+ * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
+ * and \link nn::Result::IsFailure \endlink.
  */
 static inline nn::Result
 GetStartupId(ConfigIdNum *id)
@@ -61,9 +94,16 @@ GetStartupId(ConfigIdNum *id)
    return detail::GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(id);
 }
 
-
 /**
- * Connect to configuration id.
+ * Connects to a network, using the configuration represented by the given
+ * \link ConfigIdNum \endlink.
+ *
+ * \param id
+ * The \link ConfigIdNum \endlink representing the network to connect to.
+ *
+ * \return
+ * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
+ * and \link nn::Result::IsFailure \endlink.
  */
 static inline nn::Result
 Connect(ConfigIdNum id)
@@ -71,9 +111,17 @@ Connect(ConfigIdNum id)
    return detail::Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
 }
 
-
 /**
- * Get the IP address of the current connection.
+ * Gets the IP address assosciated with the currently active connection.
+ *
+ * \param ip
+ * A pointer to write the IP address to, in
+ * <a href="https://en.wikipedia.org/wiki/IPv4#Address_representations"
+ * target="_blank">numerical</a> form.
+ *
+ * \return
+ * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
+ * and \link nn::Result::IsFailure \endlink.
  */
 static inline nn::Result
 GetAssignedAddress(uint32_t *ip)

--- a/include/nn/nn.dox
+++ b/include/nn/nn.dox
@@ -1,3 +1,4 @@
 /**
  * \defgroup nn nn
+ * Helper functions and classes for other APIs
  */

--- a/include/nn/result.h
+++ b/include/nn/result.h
@@ -4,24 +4,53 @@
 /**
  * \defgroup nn_result Result
  * \ingroup nn
+ * Result structure used by nn libraries (C++: see nn::Result)
  * @{
  */
 
-/**
- * C equivalent of the C++ nn::Result
- */
 typedef struct NNResult NNResult;
 
+/**
+ * Result structure for nn libraries
+ * <!--
+ *    TODO: the actual bitfield stuff?
+ * -->
+ */
 struct NNResult
 {
+   //! Aggregate value of result bitfield
    int32_t value;
 };
 
+/**
+ * Determine if a NNResult represents a successful state.
+ *
+ * \param result
+ * The NNResult to check.
+ *
+ * \return
+ * \c 1 if the NNResult represents a success, or \c 0 otherwise.
+ *
+ * \sa
+ * - \link NNResult_IsFailure \endlink
+ */
 static inline int NNResult_IsSuccess(NNResult result)
 {
    return result.value >= 0;
 }
 
+/**
+ * Determine if a NNResult represents a failure.
+ *
+ * \param result
+ * The NNResult to check.
+ *
+ * \return
+ * \c 1 if the NNResult represents a failure, or \c 0 otherwise.
+ *
+ * \sa
+ * - \link NNResult_IsSuccess \endlink
+ */
 static inline int NNResult_IsFailure(NNResult result)
 {
    return result.value < 0;
@@ -204,11 +233,29 @@ public:
    {
    }
 
+   /**
+    * Determine if the Result instance represents a failure.
+    *
+    * \return
+    * \c trie if the Result represents a failure, or \c false otherwise.
+    *
+    * \sa
+    * - \link IsSuccess \endlink
+    */
    bool IsFailure() const
    {
       return !IsSuccess();
    }
 
+   /**
+    * Determine if the Result instance represents a successful state.
+    *
+    * \return
+    * \c true if the Result represents a success, or \c false otherwise.
+    *
+    * \sa
+    * - \link IsFailure \endlink
+    */
    bool IsSuccess() const
    {
       return mLevel >= 0;

--- a/include/nn/swkbd.h
+++ b/include/nn/swkbd.h
@@ -2,6 +2,7 @@
 
 /**
  * \defgroup nn_swkbd nn_swkbd
+ * Graphical software keyboard, supporting several languages and configurations.
  */
 
 #include <nn/swkbd/swkbd_cpp.h>

--- a/include/nn/swkbd/swkbd_cpp.h
+++ b/include/nn/swkbd/swkbd_cpp.h
@@ -9,6 +9,8 @@
 /**
  * \defgroup nn_swkbd_swkbd Software Keyboard
  * \ingroup nn_swkbd
+ * See \link nn::swkbd \endlink.
+ *
  * @{
  */
 
@@ -16,6 +18,20 @@
 
 namespace nn
 {
+
+/**
+ * Graphical software keyboard, supporting several languages and configurations.
+ * Applications should first call \link Create \endlink to initialise the
+ * library, followed by \link AppearInputForm \endlink to show a text area and
+ * virtual keyboard. Input should be forwarded to the keyboard via
+ * \link Calc \endlink, along with calls to \link CalcSubThreadFont \endlink and
+ * \link CalcSubThreadPredict \endlink. Finally, the keyboard can be rendered
+ * with \link DrawTV \endlink and \link DrawDRC \endlink. The user's interaction
+ * with the keyboard can be tracked with \link GetInputFormString \endlink,
+ * \link IsDecideOkButton \endlink and \link IsDecideCancelButton \endlink; and
+ * once satisfied the application can dismiss the keyboard with
+ * \link DisappearInputForm \endlink. Don't forget \link Destroy \endlink!
+ */
 namespace swkbd
 {
 
@@ -42,6 +58,7 @@ enum class State
    Unknown0 = 0,
 };
 
+//! Configuration options for the virtual keyboard.
 struct ConfigArg
 {
    ConfigArg()
@@ -56,6 +73,7 @@ struct ConfigArg
       unk_0xA4 = -1;
    }
 
+   //! The language to use for input
    LanguageType languageType;
    uint32_t unk_0x04;
    uint32_t unk_0x08;
@@ -94,19 +112,23 @@ WUT_CHECK_OFFSET(ReceiverArg, 0x10, unk_0x10);
 WUT_CHECK_OFFSET(ReceiverArg, 0x14, unk_0x14);
 WUT_CHECK_SIZE(ReceiverArg, 0x18);
 
+//! Arguments for the swkbd keyboard
 struct KeyboardArg
 {
+   //! Configuration for the keyboard itself
    ConfigArg configArg;
    ReceiverArg receiverArg;
 };
 WUT_CHECK_SIZE(KeyboardArg, 0xC0);
 
+//! Arguments for swkbd the input form (text area).
 struct InputFormArg
 {
    uint32_t unk_0x00 = 1;
    int32_t unk_0x04 = -1;
    uint32_t unk_0x08 = 0;
    uint32_t unk_0x0C = 0;
+   //! The maximum number of characters that can be entered, -1 for unlimited.
    int32_t maxTextLength = -1;
    uint32_t unk_0x14 = 0;
    uint32_t unk_0x18 = 0;
@@ -127,18 +149,25 @@ WUT_CHECK_OFFSET(InputFormArg, 0x1D, unk_0x1D);
 WUT_CHECK_OFFSET(InputFormArg, 0x1E, unk_0x1E);
 WUT_CHECK_SIZE(InputFormArg, 0x20);
 
+//! Arguments for the swkbd input form and keyboard.
 struct AppearArg
 {
+   //! Arguments for the virtual keyboard
    KeyboardArg keyboardArg;
+   //! Arguments for the input form (text area)
    InputFormArg inputFormArg;
 };
 WUT_CHECK_SIZE(AppearArg, 0xE0);
 
+//!The arguments used to initialise swkbd and pass in its required resources.
 struct CreateArg
 {
+   //! A pointer to a work memory buffer; see \link GetWorkMemorySize \endlink.
    void *workMemory = nullptr;
+   //! The swkbd region to use.
    RegionType regionType = RegionType::Europe;
    uint32_t unk_0x08 = 0;
+   //! An FSClient for swkbd to use while loading resources.
    FSClient *fsClient = nullptr;
 };
 WUT_CHECK_OFFSET(CreateArg, 0x00, workMemory);
@@ -147,9 +176,12 @@ WUT_CHECK_OFFSET(CreateArg, 0x08, unk_0x08);
 WUT_CHECK_OFFSET(CreateArg, 0x0C, fsClient);
 WUT_CHECK_SIZE(CreateArg, 0x10);
 
+//! Input and controller information for swkbd.
 struct ControllerInfo
 {
+   //! DRC input information, see \link VPADRead \endlink.
    VPADStatus *vpad = nullptr;
+   //! Wiimote and extension controller inputs, see \link KPADRead \endlink.
    KPADStatus *kpad[4] = { nullptr, nullptr, nullptr, nullptr };
 };
 WUT_CHECK_OFFSET(ControllerInfo, 0x00, vpad);
@@ -180,45 +212,169 @@ struct IEventReceiver;
 struct IControllerEventObj;
 struct ISoundObj;
 
+/**
+ * Show an input form (keyboard with text area) with the given configuration.
+ *
+ * \param args
+ * An \link nn::swkbd::AppearArg AppearArg \endlink struct with the desired
+ * configuration for the keyboard and input form.
+ *
+ * \return
+ * \c true on success, or \c false on error.
+ *
+ * \sa
+ * - \link DisappearInputForm \endlink
+ * - \link GetInputFormString \endlink
+ * - \link IsDecideOkButton \endlink
+ * - \link IsDecideCancelButton \endlink
+ */
 bool
 AppearInputForm(const AppearArg& args);
 
+/**
+ * Show a keyboard with the given configuration.
+ *
+ * \param args
+ * An \link nn::swkbd::KeyboardArg KeyboardArg \endlink struct with the desired
+ * configuration for the keyboard.
+ *
+ * \return
+ * \c true on success, or \c false on error.
+ *
+ * \sa
+ * - \link DisappearKeyboard \endlink
+ * - \link IsDecideOkButton \endlink
+ * - \link IsDecideCancelButton \endlink
+ */
 bool
 AppearKeyboard(const KeyboardArg& args);
 
+/**
+ * Calculate font data. Call in response to
+ * \link IsNeedCalcSubThreadFont \endlink.
+ *
+ * \sa
+ * - \link CalcSubThreadPredict \endlink
+ * - \link Calc \endlink
+ */
 void
 CalcSubThreadFont();
 
+/**
+ * Calculate word prediction data. Call in response to
+ * \link IsNeedCalcSubThreadPredict \endlink.
+ *
+ * \sa
+ * - \link CalcSubThreadFont \endlink
+ * - \link Calc \endlink
+ */
 void
 CalcSubThreadPredict();
 
+/**
+ * Respond to user inputs and calculate the state of input buffers and graphics.
+ *
+ * \param controllerInfo
+ * A \link nn::swkbd::ControllerInfo ControllerInfo \endlink structure
+ * containing fresh data from the controllers (see \link VPADRead \endlink
+ * and \link KPADRead \endlink). Each controller can also be \c nullptr if data
+ * is not available.
+ *
+ * \sa
+ * - \link CalcSubThreadFont \endlink
+ * - \link CalcSubThreadPredict \endlink
+ */
 void
 Calc(const ControllerInfo &controllerInfo);
 
 void
 ConfirmUnfixAll();
 
+/**
+ * Initialise the swkbd library and create the keyboard and input form.
+ *
+ * \param args
+ * A \link nn::swkbd::CreateArg CreateArg \endlink structure containing the
+ * desired keyboard region, a pointer to work memory, and an
+ * \link FSClient \endlink. See \link nn::swkbd::CreateArg CreateArg\endlink.
+ *
+ * \return
+ * \c true on success, \c false otherwise.
+ *
+ * \sa
+ * - \link Destroy \endlink
+ * - \link GetWorkMemorySize \endlink
+ */
 bool
 Create(const CreateArg &args);
 
+/**
+ * Clean up and shut down the swkbd library.
+ *
+ * \note
+ * Resources passed into \link Create \endlink (work memory, filesystem client)
+ * must be manually freed by the application <em>after</em> calling this
+ * function.
+ *
+ * \sa
+ * - \link Create \endlink
+ */
 void
 Destroy();
 
+/**
+ * Hide a previously shown input form.
+ *
+ * \return
+ * \c true on success, \c false otherwise.
+ *
+ * \sa
+ * - \link AppearInputForm \endlink
+ * - \link GetInputFormString \endlink
+ */
 bool
 DisappearInputForm();
 
+/**
+ * Hide a previously shown keyboard.
+ *
+ * \return
+ * \c true on success, \c false otherwise.
+ *
+ * \sa
+ * - \link AppearKeyboard \endlink
+ */
 bool
 DisappearKeyboard();
 
+/**
+ * Draw the keyboard to the DRC. Must be called inside a valid GX2 rendering
+ * context, after rendering all other DRC graphics (to appear under the
+ * keyboard)
+ */
 void
 DrawDRC();
 
+/**
+ * Draw the keyboard to the TV. Must be called inside a valid GX2 rendering
+ * context, after rendering all other TV graphics (to appear under the
+ * keyboard)
+ */
 void
 DrawTV();
 
 void
 GetDrawStringInfo(DrawStringInfo *drawStringInfo);
 
+/**
+ * Get the string the user typed into the input form.
+ *
+ * \returns
+ * The user's text, as a null-terminated UTF-16 string.
+ *
+ * \sa
+ * - \link SetInputFormString \endlink
+ */
 const char16_t *
 GetInputFormString();
 
@@ -231,12 +387,24 @@ GetStateInputForm();
 State
 GetStateKeyboard();
 
+/**
+ * Get the required size for swkbd's work memory buffer. The application must
+ * allocate a buffer of this size and pass it into \link Create \endlink.
+ *
+ * \param unk
+ * Unknown. A value of 0 seems to work.
+ *
+ * \return
+ * The required size of the work buffer, in bytes.
+ *
+ * \sa
+ * - \link Create \endlink
+ */
 uint32_t
 GetWorkMemorySize(uint32_t unk);
 
 void
 InactivateSelectCursor();
-
 
 bool
 InitLearnDic(void *dictionary);
@@ -244,36 +412,122 @@ InitLearnDic(void *dictionary);
 bool
 IsCoveredWithSubWindow();
 
+/**
+ * Gets the current status of the Cancel button on the keyboard.
+ *
+ * \param outIsSelected
+ * Pointer to a boolean to write the button status to, or \c nullptr if the
+ * return value is enough.
+ *
+ * \return
+ * \c true if the Cancel button has been pressed, or \c false otherwise.
+ *
+ * \sa
+ * - \link IsDecideOkButton \endlink
+ */
 bool
 IsDecideCancelButton(bool *outIsSelected);
 
+/**
+ * Gets the current status of the OK button on the keyboard.
+ *
+ * \param outIsSelected
+ * Pointer to a boolean to write the button status to, or \c nullptr if the
+ * return value is enough.
+ *
+ * \return
+ * \c true if the OK button has been pressed, or \c false otherwise.
+ *
+ * \sa
+ * - \link IsDecideCancelButton \endlink
+ */
 bool
 IsDecideOkButton(bool *outIsSelected);
 
 bool
 IsKeyboardTarget(IEventReceiver *eventReceiver);
 
+/**
+ * Determines whether the font data needs calculating. If it does, a call to
+ * \link CalcSubThreadFont \endlink is required.
+ *
+ * \return
+ * \c true if the font data needs calculating, \c false otherwise.
+ *
+ * \sa
+ * - \link IsNeedCalcSubThreadPredict \endlink
+ */
 bool
 IsNeedCalcSubThreadFont();
 
+/**
+ * Determines whether the prediction data needs calculating. If it does, a call
+ * to \link CalcSubThreadPredict \endlink is required.
+ *
+ * \return
+ * \c true if the prediction data needs calculating, \c false otherwise.
+ *
+ * \sa
+ * - \link IsNeedCalcSubThreadFont \endlink
+ */
 bool
 IsNeedCalcSubThreadPredict();
 
+/**
+ * Determines whether the selection cursor is active.
+ *
+ * \return
+ * \c true if the selection cursor is active, \c false otherwise.
+ */
 bool
 IsSelectCursorActive();
 
+/**
+ * Mutes or unmutes the sounds generated by the keyboard.
+ *
+ * \param muted
+ * \c true to disable all sounds, or \c false to enable them.
+ */
 void
 MuteAllSound(bool muted);
 
 void
 SetControllerRemo(ControllerType type);
 
+/**
+ * Set the character at which the cursor is positioned.
+ *
+ * \param pos
+ * The position at which to move the cursor, with 0 corresponding to the start
+ * of the string (before the first character).
+ *
+ * <!--
+ *     TODO: check factual accuracy?
+ *     Does one need to account for multiword UTF-16 characters?
+ * -->
+ */
 void
-SetCursorPos(int);
+SetCursorPos(int pos);
 
+/**
+ * Enables and disables the OK button on the keyboard. When disabled, the button
+ * cannot be pressed.
+ *
+ * \param enable
+ * \c true to enable the button, or \c false to disable it.
+ */
 void
-SetEnableOkButton(bool);
+SetEnableOkButton(bool enable);
 
+/**
+ * Sets the text in the input form.
+ *
+ * \param str
+ * The UTF-16 string to set the input form to.
+ *
+ * \sa
+ * - \link GetInputFormString \endlink
+ */
 void
 SetInputFormString(const char16_t *str);
 

--- a/include/swkbd/rpl_interface.h
+++ b/include/swkbd/rpl_interface.h
@@ -5,6 +5,7 @@
 /**
  * \defgroup swkbd_rpl RPL Interface
  * \ingroup swkbd
+ * C++ linkage for swkbd, see \link nn::swkbd \endlink for general use.
  * @{
  */
 

--- a/include/swkbd/swkbd.dox
+++ b/include/swkbd/swkbd.dox
@@ -1,5 +1,6 @@
 /**
  * \defgroup swkbd swkbd
  *
- * Software Keyboard library.
+ * C++ linkage for the software keyboard, see \link nn::swkbd \endlink for
+ * general use.
  */

--- a/include/sysapp/launch.h
+++ b/include/sysapp/launch.h
@@ -17,8 +17,9 @@ extern "C" {
 
 /**
  * Restarts the current title with new arguments once the running application
- * quits. Instead of returning to the HOME menu upon exit, the system will start
- * the same title again.
+ * quits, and requests the application exit immediately (through \link
+ * proc_ui_procui ProcUI\endlink). Instead of returning to the HOME menu upon
+ * exit, the system will start the same title again.
  *
  * \param argc
  * The number of strings in the pa_Argv array. Passed in to the title's main
@@ -39,7 +40,8 @@ SYSRelaunchTitle(uint32_t argc,
                  char *pa_Argv[]);
 
 /**
- * Launches the HOME menu when the current application exits.
+ * Launches the HOME menu when the current application exits, and requests the
+ * application exit immediately (through \link proc_ui_procui ProcUI\endlink).
  *
  * \note
  * This is the default behaviour upon application exit.
@@ -48,9 +50,11 @@ void
 SYSLaunchMenu();
 
 /**
- * Launch the given title ID once the current applocation exits. Instead of
- * opening the HOME menu once the current application quits, the system will
- * load the given title with default arguments.
+ * Launch the given title ID once the current application exits, and requests
+ * the application exit immediately (through
+ * \link proc_ui_procui ProcUI\endlink). Instead of opening the HOME menu once
+ * the current application quits, the system will load the given title with
+ * default arguments.
  *
  * <!--
  *    what happens on an incorrect titleid?
@@ -62,6 +66,7 @@ SYSLaunchTitle(uint64_t TitleId);
 
 /**
  * Launch Mii Maker once the current application exits.
+ * <!-- there's a version without the underscore, use that? -->
  */
 void
 _SYSLaunchMiiStudio();

--- a/include/sysapp/switch.h
+++ b/include/sysapp/switch.h
@@ -29,7 +29,6 @@ typedef struct SysAppBrowserArgs SysAppBrowserArgs;
  * The current application is moved into the background (see \link
  * proc_ui_procui ProcUI\endlink) and the sync menu is shown. Once the user
  * exits the menu, the application is moved back to the foreground.
- * <!-- TODO check factual accuracy here -->
  */
 void
 SYSSwitchToSyncControllerOnHBM();
@@ -57,6 +56,8 @@ SYSSwitchToEShop();
 /**
  * <!--
  *    ..?
+ *    Current app moves into background then immediately back out again.
+ *    Presumably meant for overlay apps to exit?
  * -->
  */
 void

--- a/include/sysapp/title.h
+++ b/include/sysapp/title.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup sysapp_title SYSAPP Title
+ * \ingroup sysapp
+ *
+ * Functions to check titles and their IDs, as well as retreiving some metadata
+ * about them.
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Check if a given title exists and is installed on the system.
+ *
+ * \param TitleId
+ * The ID of the title to check.
+ *
+ * \return
+ * \c TRUE if the title exists, or \c FALSE otherwise.
+ */
+BOOL
+SYSCheckTitleExists(uint64_t TitleId);
+
+/**
+ * Gets the PFID/UPID for a given title.
+ *
+ * \param TitleId
+ * The ID of the title to get the PFID/UPID from.
+ *
+ * \return
+ * The PFID/UPID for the title, or a negative value on error.
+ *
+ * \note
+ * This function is identical to \link SYSGetUPIDFromTitleID \endlink.
+ */
+int32_t
+SYSGetPFIDFromTitleID(uint64_t TitleId);
+
+/**
+ * Gets the PFID/UPID for a given title.
+ *
+ * \param TitleId
+ * The ID of the title to get the PFID/UPID from.
+ *
+ * \return
+ * The PFID/UPID for the title, or a negative value on error.
+ *
+ * \note
+ * This function is identical to \link SYSGetPFIDFromTitleID \endlink.
+ */
+int32_t
+SYSGetUPIDFromTitleID(uint64_t TitleId);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
Heyo!
Another round of documentation updates, big-ticket one here is swkbd. I know it hasn't been fully RE'd yet, but the example was good enough to get the important functions done! Also chucked in nn::ac and nn::Result for good measure; since doxygen's C++ layout is a little weird and it made sense to have the index pages look better.
devkitPro peeps - I usually do this branch/PR thing so exjam has a chance to catch any mistakes (it's happened before!) Sorry if you get an email about it.
-Ash