### PR TITLE
devoptab: Fix double free in __wut_fs_stat

### DIFF
--- a/libraries/wutdevoptab/devoptab_fs_stat.c
+++ b/libraries/wutdevoptab/devoptab_fs_stat.c
@@ -45,6 +45,5 @@ __wut_fs_stat(struct _reent *r,
    st->st_nlink = 1;
    st->st_mode = S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO;
    FSCloseDir(__wut_devoptab_fs_client, &cmd, fd, -1);
-   free(fixedPath);
    return 0;
 }


### PR DESCRIPTION
The double free caused apps to crash when attempting to run stat on a directory