### PR TITLE
Fix URL

### DIFF
--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -3,7 +3,7 @@
  *
  * \section Introduction
  * An experimental in-development Wii U toolchain, the source can be found at
- * https://github.com/decaf-emu/wut
+ * https://github.com/devkitPro/wut
  *
  * \section Usage
  * TODO.

--- a/include/wut.h
+++ b/include/wut.h
@@ -1,9 +1,9 @@
 #pragma once
 
 /*
- * wut 1.0.0-alpha
+ * wut 1.0.0-beta
  *
- * https://github.com/decaf-emu/wut
+ * https://github.com/devkitPro/wut
  */
 
 #include "wut_structsize.h"


### PR DESCRIPTION
wut is now part of devkitPro, so the repo is now located at https://github.com/devkitPro/wut
Version was also changed from alpha to beta to reflect the current project status.