### PR TITLE
Add missing functions to coreinit/debug.h

### DIFF
--- a/include/coreinit/debug.h
+++ b/include/coreinit/debug.h
@@ -60,6 +60,17 @@ OSGetSymbolName(uint32_t addr,
 uint32_t
 OSGetUPID();
 
+BOOL
+OSIsDebuggerInitialized();
+
+BOOL
+OSIsDebuggerPresent();
+
+BOOL
+OSIsECOBoot();
+
+BOOL
+OSIsECOMode();
 
 BOOL
 DisassemblePPCOpcode(uint32_t *opcode,


### PR DESCRIPTION
- add function OSIsDebuggerInitialized
- add function OSIsDebuggerPresent
- add function OSIsECOBoot
- add function OSIsECOMode