### PR TITLE
Coreinit: Remove duplicate function (OSMemoryBarrier) 

### DIFF
--- a/include/coreinit/memory.h
+++ b/include/coreinit/memory.h
@@ -146,9 +146,6 @@ OSGetMemBound(OSMemoryType type,
               uint32_t *outAddr,
               uint32_t *outSize);
 
-void
-OSMemoryBarrier();
-
 /**
  * Zeros the memory for a given proccessID. 
  * Works only inside the ROOT process.


### PR DESCRIPTION
(already exist in coreinit/cache.h)