### PR TITLE
wutdevoptab: Reset `__wut_fs_initialised` and `__wut_devoptab_fs_client` in `__fini_wut_devoptab`

### DIFF
--- a/libraries/wutdevoptab/devoptab_fs.c
+++ b/libraries/wutdevoptab/devoptab_fs.c
@@ -106,6 +106,8 @@ __fini_wut_devoptab()
    FSDelClient(__wut_devoptab_fs_client, -1);
    free(__wut_devoptab_fs_client);
    
+   RemoveDevice(__wut_fs_devoptab.name);
+   
    __wut_devoptab_fs_client = NULL;   
    __wut_fs_initialised = FALSE;
    

--- a/libraries/wutdevoptab/devoptab_fs.c
+++ b/libraries/wutdevoptab/devoptab_fs.c
@@ -105,5 +105,9 @@ __fini_wut_devoptab()
 
    FSDelClient(__wut_devoptab_fs_client, -1);
    free(__wut_devoptab_fs_client);
+   
+   __wut_devoptab_fs_client = NULL;   
+   __wut_fs_initialised = FALSE;
+   
    return rc;
 }


### PR DESCRIPTION
It may be useful for an application to call to (de)-init the devoptabs multiple times