### PR TITLE
Add link time optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ INCLUDES	:=	include \
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CFLAGS	:=	-g -Wall -Werror -save-temps \
+CFLAGS	:=	-Wall -Werror -save-temps \
 			-ffunction-sections -fdata-sections \
 			$(MACHDEP) \
 			$(BUILD_CFLAGS)
@@ -125,7 +125,7 @@ debug:
 
 lib/libwut.a : lib release $(SOURCES) $(INCLUDES)
 	@$(MAKE) BUILD=release OUTPUT=$(CURDIR)/$@ \
-	BUILD_CFLAGS="-DNDEBUG=1 -O2" \
+	BUILD_CFLAGS="-DNDEBUG=1 -O2 -flto=auto -ffat-lto-objects -fuse-linker-plugin" \
 	DEPSDIR=$(CURDIR)/release \
 	--no-print-directory -C release \
 	-f $(CURDIR)/Makefile

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ INCLUDES	:=	include \
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-CFLAGS	:=	-Wall -Werror -save-temps \
+CFLAGS	:=	-Wall -Werror -pipe \
 			-ffunction-sections -fdata-sections \
 			$(MACHDEP) \
 			$(BUILD_CFLAGS)


### PR DESCRIPTION
As WUT is a library we build as fat-lto-objects. That way both, non-LTO and LTO homebrew are able to link with ease.