### PR TITLE
Add more VPAD definitions

### DIFF
--- a/include/nn/pdm/pdm_cpp.h
+++ b/include/nn/pdm/pdm_cpp.h
@@ -35,7 +35,7 @@ struct WUT_PACKED PlayDiary
    uint32_t playtime;
    //! Date in days since 01/01/2000
    uint16_t date;
-   //! flags \link PlayDiaryFlags \endif
+   //! flags \link PlayDiaryFlags \endlink
    PlayDiaryFlags flags;
 };
 WUT_CHECK_OFFSET(PlayDiary, 0x00, title_id);

--- a/include/vpad/input.h
+++ b/include/vpad/input.h
@@ -553,6 +553,10 @@ VPADSetRStickClampThreshold(VPADChan chan,
                             int32_t min);
 
 void
+VPADGetGyroDirReviseParam(VPADChan chan,
+                          float *param);
+
+void
 VPADGetGyroZeroDriftMode(VPADChan chan,
                          VPADGyroZeroDriftMode *mode);
 
@@ -616,6 +620,10 @@ VPADSetGyroDirReviseBase(VPADChan chan,
                          VPADDirection *base);
 
 void
+VPADSetGyroDirReviseParam(VPADChan chan,
+                          float param);
+
+void
 VPADSetGyroDirection(VPADChan chan,
                      VPADDirection *dir);
 
@@ -676,6 +684,12 @@ VPADInitGyroDirReviseParam(VPADChan chan);
 
 void
 VPADInitGyroAccReviseParam(VPADChan chan);
+
+void
+VPADStartGyroMagRevise(VPADChan chan);
+
+void
+VPADStopGyroMagRevise(VPADChan chan);
 
 /**
  * Initializes the zero drift mode on the desired Gamepad.

--- a/include/vpad/input.h
+++ b/include/vpad/input.h
@@ -125,12 +125,21 @@ typedef enum VPADReadError
 typedef enum VPADLcdMode
 {
    //! Display is in standby and will turn back on if any buttons are pressed.
-   VPAD_LCD_STANDBY = 0,
+   VPAD_LCD_STANDBY              = 0,
    //! Display is completely off and will remain so until explicitly changed.
-   VPAD_LCD_OFF = 1,
+   VPAD_LCD_OFF                  = 1,
    //! Display is on as normal.
-   VPAD_LCD_ON = 0xFF,
+   VPAD_LCD_ON                   = 0xFF,
 } VPADLcdMode;
+
+//! Gyro zero drift mode.
+typedef enum VPADGyroZeroDriftMode
+{
+   VPAD_GYRO_ZERODRIFT_LOOSE     = 0,
+   VPAD_GYRO_ZERODRIFT_STANDARD,
+   VPAD_GYRO_ZERODRIFT_TIGHT,
+   VPAD_GYRO_ZERODRIFT_NONE
+} VPADGyroZeroDriftMode;
 
 //! 2D vector.
 struct VPADVec2D
@@ -544,6 +553,10 @@ VPADSetRStickClampThreshold(VPADChan chan,
                             int32_t min);
 
 void
+VPADGetGyroZeroDriftMode(VPADChan chan,
+                         VPADGyroZeroDriftMode *mode);
+
+void
 VPADGetLStickClampThreshold(VPADChan chan,
                             int32_t *max,
                             int32_t *min);
@@ -617,6 +630,10 @@ VPADSetGyroMagnification(VPADChan chan,
                          float roll);
 
 void
+VPADSetGyroZeroDriftMode(VPADChan chan,
+                         VPADGyroZeroDriftMode mode);
+
+void
 VPADEnableGyroZeroPlay(VPADChan chan);
 
 void
@@ -660,6 +677,16 @@ VPADInitGyroDirReviseParam(VPADChan chan);
 void
 VPADInitGyroAccReviseParam(VPADChan chan);
 
+/**
+ * Initializes the zero drift mode on the desired Gamepad.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * The channel of the Gamepad to initialize.
+ */
 void
 VPADInitGyroZeroDriftMode(VPADChan chan);
 

--- a/include/vpad/input.h
+++ b/include/vpad/input.h
@@ -705,6 +705,39 @@ void
 VPADInitGyroZeroDriftMode(VPADChan chan);
 
 /**
+ * Get the TV menu status.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * The channel of the Gamepad to get the TV status from.
+ *
+ * \returns
+ * TRUE if the TV menu is shown, FALSE otherwise.
+ */
+BOOL
+VPADGetTVMenuStatus(VPADChan chan);
+
+/**
+ * Enable or disable the TV menu.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * The channel of the Gamepad to enable or disable the TV menu from.
+ *
+ * \param invalid
+ * Set to TRUE to disable the TV menu or FALSE to enable it.
+ */
+void
+VPADSetTVMenuInvalid(VPADChan chan,
+                     BOOL invalid);
+
+/**
  * Turns on the rumble motor on the desired Gamepad.
  * A custom rumble pattern can be set by setting bytes in the input buffer.
  *


### PR DESCRIPTION
Add definitions for

- VPADGetGyroZeroDriftMode
- VPADSetGyroZeroDriftMode
- VPADGetGyroDirReviseParam
- VPADSetGyroDirReviseParam
- VPADStartGyroMagRevise
- VPADStopGyroMagRevise
- VPADGetTVMenuStatus
- VPADSetTVMenuInvalid
