### PR TITLE
Publish documentation when pushing to a tag

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,31 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  doc:
+    name: Deploy documentation
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Checkout the Git repository
+      uses: actions/checkout@v2
+
+    - name: Generate Documentation
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake doxygen doxygen-latex graphviz
+        cd docs
+        sudo cmake .
+        doxygen Doxyfile.docs >/dev/null
+
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@3.6.2
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: docs/html

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,8 +2,8 @@ name: Documentation
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - '*'
 
 jobs:
   doc:
@@ -24,8 +24,7 @@ jobs:
         doxygen Doxyfile.docs >/dev/null
 
     - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@3.6.2
+      uses: JamesIves/github-pages-deploy-action@4.1.1
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: docs/html
+        branch: gh-pages
+        folder: docs/html

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,7 @@ jobs:
         doxygen Doxyfile.docs >/dev/null
 
     - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@4.2.3
+      uses: JamesIves/github-pages-deploy-action@v4.2.3
       with:
         branch: gh-pages
         folder: docs/html

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,10 @@ jobs:
         doxygen Doxyfile.docs >/dev/null
 
     - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@4.1.1
+      uses: JamesIves/github-pages-deploy-action@4.2.3
       with:
         branch: gh-pages
         folder: docs/html
+        single-commit: true
+        clean: true
+        clean-exclude: CNAME


### PR DESCRIPTION
This PR will publish the doxygen documentation to GitHub Pages when pushing ~~to the master branch~~ a tag.

With the current wut project configuration, this PR is a bit useless. Right now the GitHub Pages is set to use a Custom domain. So when you go to https://devkitPro.github.io/wut you are redirected to https://wut.devkitpro.org.

If you want to keep this behavior:
1. I would recommend to delete the [gh-pages](https://github.com/devkitPro/wut/tree/gh-pages) branch so we know it's not use
2. I would also update the doc on the server to have the latest version
3. And of course I would close this PR

If not... please accept this PR and change the GitHub Pages project Settings 😁