### PR TITLE
WHB: Fix missing FSDelClient calls

### DIFF
--- a/libraries/libwhb/include/whb/file.h
+++ b/libraries/libwhb/include/whb/file.h
@@ -17,6 +17,9 @@ typedef enum WHBFileError
    WHB_FILE_FATAL_ERROR = -1,
 } WHBFileError;
 
+BOOL
+WHBDeInitFileSystem();
+
 int32_t
 WHBOpenFile(const char *path,
             const char *mode);

--- a/libraries/libwhb/src/file.c
+++ b/libraries/libwhb/src/file.c
@@ -26,6 +26,20 @@ InitFileSystem()
    return TRUE;
 }
 
+BOOL
+WHBDeInitFileSystem()
+{
+    if (sInitialised) {
+      if (FSDelClient(&sClient, -1) != FS_STATUS_OK) {
+         return FALSE;
+      }
+
+      sInitialised = FALSE;
+    }
+
+    return TRUE;
+}
+
 int32_t
 WHBOpenFile(const char *path,
             const char *mode)

--- a/libraries/libwhb/src/sdcard.c
+++ b/libraries/libwhb/src/sdcard.c
@@ -74,6 +74,12 @@ WHBUnmountSdCard()
       WHBLogPrintf("%s: FSUnmount error %d", __FUNCTION__, result);
       return FALSE;
    }
+   
+   result = FSDelClient(&sClient, -1);
+   if (result < 0) {
+      WHBLogPrintf("%s: FSDelClient error %d", __FUNCTION__, result);
+      return FALSE;
+   }
 
    sMounted = FALSE;
    return TRUE;


### PR DESCRIPTION
WHB is adding FSClients but never deletes them. 
Faulty FSClient entries may lead to crashes when trying to add a new client.

Normaly this is not a problem because the memoy is cleared when exiting an application, but when chainloading multiple payloads previous FSClients may be overriden and therefore corrupted. When a corrupted FSClient is still added, adding new clients will crash the console.

Example crash dump:
```
Core1: Instruction at 0x010670E0 (from SRR0) invalid access of 0x00001614 (value from DAR)
00;00;17;710: 
--Proc15-Core1--------- OSContext 0x100457E0 --------------------

00;00;17;710: tag1  = 0x4F53436F (expecting 0x4F53436F)
00;00;17;710: tag2  = 0x6E747874 (expecting 0x6E747874)
00;00;17;710: TBR   = 0x00000000_2BA7A7A2
00;00;17;710: CR    = 0x84200024
INFO: nn::ipc avoided busy close on /dev/acp_main (moduleId = 301, tag = 0) from pid = 21
00;00;17;710: CTR   = 0x01069444
00;00;17;710: LR    = 0x010670A0 coreinit.rpl|FSAGetFileBlockAddressAsync+0x13C
00;00;17;710: SRR0  = 0x010670E0 coreinit.rpl|FSAGetFileBlockAddressAsync+0x13C
00;00;17;710: SRR1  = 0x0000D072

00;00;17;710: state = 0x0006

00;00;17;710: r0   = 0x00000000 (             0)  r16  = 0x00000000 (             0)
00;00;17;710: r1   = 0x1053c600 (     273925632)  r17  = 0x00000000 (             0)
00;00;17;710: r2   = 0xffec13e0 (      -1305632)  r18  = 0x00000000 (             0)
00;00;17;710: r3   = 0x10175e4c (     269966924)  r19  = 0x10838680 (     277055104)
00;00;17;710: r4   = 0x100457e0 (     268720096)  r20  = 0x10060540 (     268830016)
00;00;17;710: r5   = 0x00000001 (             1)  r21  = 0x00000001 (             1)
00;00;17;710: r6   = 0x100457e0 (     268720096)  r22  = 0x00886fe0 (       8941536)
00;00;17;710: r7   = 0x00000000 (             0)  r23  = 0x00886f83 (       8941443)
00;00;17;710: r8   = 0x00000002 (             2)  r24  = 0x109177b8 (     277968824)
00;00;17;710: r9   = 0x0000001c (            28)  r25  = 0x10170000 (     269942784)
00;00;17;710: r10  = 0x100457e0 (     268720096)  r26  = 0x00000000 (             0)
00;00;17;710: r11  = 0x00000000 (             0)  r27  = 0x100520ec (     268771564)
00;00;17;710: r12  = 0x105ecdc0 (     274648512)  r28  = 0x100520e8 (     268771560)
00;00;17;710: r13  = 0xffeb2500 (      -1366784)  r29  = 0x10840580 (     277087616)
00;00;17;710: r14  = 0x00000000 (             0)  r30  = 0x10170000 (     269942784)
00;00;17;710: r15  = 0x00000000 (             0)  r31  = 0x10840580 (     277087616)
00;00;17;710: 
--Stack Trace--------------------------
00;00;17;711: 
Address:      Back Chain    LR Save
00;00;17;711: 0x1053c600:   0x1053c610    0x0104a0e0 coreinit.rpl|MEMAllocFromExpHeapEx+0xe0
00;00;17;711: 0x1053c610:   0x1053c638    0x01069118 coreinit.rpl|FSAddClientEx+0xd4
```
