### PR TITLE
Add Log handler for Cemu

### DIFF
--- a/libraries/libwhb/include/whb/log_cemu.h
+++ b/libraries/libwhb/include/whb/log_cemu.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup whb_log_cemu Cemu Log Output
+ * \ingroup whb
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+BOOL
+WHBLogCemuInit();
+
+BOOL
+WHBLogCemuDeinit();
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/libraries/libwhb/src/log_cemu.c
+++ b/libraries/libwhb/src/log_cemu.c
@@ -1,0 +1,28 @@
+#include <coreinit/debug.h>
+#include <whb/log.h>
+
+#include <string.h>
+
+static void
+cemuLogHandler(const char * msg)
+{
+   uint32_t size = strlen(msg);
+   if (size > 0 && msg[size-1] == '\n') {
+      // OSConsoleWrite on Cemu already adds a new line
+      size--;
+   }
+
+   OSConsoleWrite(msg, size);
+}
+
+BOOL
+WHBLogCemuInit()
+{
+   return WHBAddLogHandler(cemuLogHandler);
+}
+
+BOOL
+WHBLogCemuDeinit()
+{
+   return WHBRemoveLogHandler(cemuLogHandler);
+}


### PR DESCRIPTION
Cemu does not log messages from OSReport, but it does log messages from OSConsoleWrite, so, let's use that.