### PR TITLE
wutnewlib: fix gettod implementation

### DIFF
--- a/libraries/wutnewlib/wut_clock.c
+++ b/libraries/wutnewlib/wut_clock.c
@@ -1,23 +1,8 @@
 #include "wut_newlib.h"
+#include "wut_clock.h"
 
 #include <coreinit/systeminfo.h>
 #include <coreinit/time.h>
-
-// The Wii U epoch is at 2000, so we must map it to 1970 for gettime
-#define WIIU_EPOCH_YEAR (2000)
-
-#define EPOCH_YEAR (1970)
-#define EPOCH_YEARS_SINCE_LEAP 2
-#define EPOCH_YEARS_SINCE_CENTURY 70
-#define EPOCH_YEARS_SINCE_LEAP_CENTURY 370
-
-#define EPOCH_DIFF_YEARS (2000 - EPOCH_YEAR)
-#define EPOCH_DIFF_DAYS \
-   ((EPOCH_DIFF_YEARS * 365) + \
-    (EPOCH_DIFF_YEARS - 1 + EPOCH_YEARS_SINCE_LEAP) / 4 - \
-    (EPOCH_DIFF_YEARS - 1 + EPOCH_YEARS_SINCE_CENTURY) / 100 + \
-    (EPOCH_DIFF_YEARS - 1 + EPOCH_YEARS_SINCE_LEAP_CENTURY) / 400)
-#define EPOCH_DIFF_SECS (60ull * 60ull * 24ull * (uint64_t)EPOCH_DIFF_DAYS)
 
 int
 __wut_clock_gettime(clockid_t clock_id,

--- a/libraries/wutnewlib/wut_clock.h
+++ b/libraries/wutnewlib/wut_clock.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// The Wii U epoch is at 2000, so we must map it to 1970 for gettime
+#define WIIU_EPOCH_YEAR (2000)
+
+#define EPOCH_YEAR (1970)
+#define EPOCH_YEARS_SINCE_LEAP 2
+#define EPOCH_YEARS_SINCE_CENTURY 70
+#define EPOCH_YEARS_SINCE_LEAP_CENTURY 370
+
+#define EPOCH_DIFF_YEARS (2000 - EPOCH_YEAR)
+#define EPOCH_DIFF_DAYS \
+   ((EPOCH_DIFF_YEARS * 365) + \
+    (EPOCH_DIFF_YEARS - 1 + EPOCH_YEARS_SINCE_LEAP) / 4 - \
+    (EPOCH_DIFF_YEARS - 1 + EPOCH_YEARS_SINCE_CENTURY) / 100 + \
+    (EPOCH_DIFF_YEARS - 1 + EPOCH_YEARS_SINCE_LEAP_CENTURY) / 400)
+#define EPOCH_DIFF_SECS (60ull * 60ull * 24ull * (uint64_t)EPOCH_DIFF_DAYS)

--- a/libraries/wutnewlib/wut_gettod_r.c
+++ b/libraries/wutnewlib/wut_gettod_r.c
@@ -1,4 +1,5 @@
 #include "wut_newlib.h"
+#include "wut_clock.h"
 
 #include <coreinit/time.h>
 
@@ -7,12 +8,15 @@ __wut_gettod_r(struct _reent *ptr,
                struct timeval *tp,
                struct timezone *tz)
 {
-   OSCalendarTime tm;
-   OSTicksToCalendarTime(OSGetTime(), &tm);
+   OSTime time = OSGetTime();
 
    if (tp != NULL) {
-      tp->tv_sec = tm.tm_sec;
-      tp->tv_usec = tm.tm_usec + tm.tm_msec * 1000;
+      tp->tv_sec = (time_t)OSTicksToSeconds(time);
+
+      time -= OSSecondsToTicks(tp->tv_sec);
+      tp->tv_usec = (long)OSTicksToMicroseconds(time);
+
+      tp->tv_sec += EPOCH_DIFF_SECS;
    }
 
    if (tz != NULL) {


### PR DESCRIPTION
It currently uses OSCalendarTime.tm_sec which contains the seconds of the current minute from 0-59 and not the seconds since the epoch.
