### PR TITLE
libwutsocket: Add missing AC* function, fix blocking on start, add way to init socket devoptab from custom implemenation

### DIFF
--- a/include/nn/ac/ac_c.h
+++ b/include/nn/ac/ac_c.h
@@ -44,7 +44,8 @@ void
 ACFinalize();
 
 /**
- * Connects to a network, using the default configuration
+ * Connects synchronically to a network, using the default configuration
+ * May be blocking until the console successfully connects or has an timeout.
  *
  * \return
  * A \link nn_result Result\endlink - see \link NNResult_IsSuccess \endlink
@@ -52,6 +53,29 @@ ACFinalize();
  */
 NNResult
 ACConnect();
+
+/**
+ * Connects asynchronically to a network, using the default configuration
+ *
+ * \return
+ * A \link nn_result Result\endlink - see \link NNResult_IsSuccess \endlink
+ * and \link NNResult_IsFailure \endlink.
+ */
+NNResult
+ACConnectAsync();
+
+/**
+ * Closes connections made with ACConnect. Use GetCloseStatus to get the status.
+ *
+ * \return
+ * A \link nn_result Result\endlink - see \link NNResult_IsSuccess \endlink
+ * and \link NNResult_IsFailure \endlink.
+ */
+NNResult
+ACClose();
+
+NNResult
+ACGetCloseStatus();
 
 /**
  * Checks whether the console is currently connected to a network.

--- a/include/nn/ac/ac_cpp.h
+++ b/include/nn/ac/ac_cpp.h
@@ -38,6 +38,10 @@ extern "C"
 
 nn::Result Initialize__Q2_2nn2acFv();
 void Finalize__Q2_2nn2acFv();
+nn::Result Connect__Q2_2nn2acFv();
+nn::Result ConnectAsync__Q2_2nn2acFv();
+nn::Result Close__Q2_2nn2acFv();
+nn::Result GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status();
 nn::Result GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(ConfigIdNum *id);
 nn::Result Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
 nn::Result GetAssignedAddress__Q2_2nn2acFPUl(uint32_t *ip);
@@ -92,6 +96,30 @@ static inline nn::Result
 GetStartupId(ConfigIdNum *id)
 {
    return detail::GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(id);
+}
+
+static inline nn::Result
+Connect()
+{
+   return detail::Connect__Q2_2nn2acFv();
+}
+
+static inline nn::Result
+ConnectAsync()
+{
+   return detail::ConnectAsync__Q2_2nn2acFv();
+}
+
+static inline nn::Result
+Close()
+{
+   return detail::Close__Q2_2nn2acFv();
+}
+
+static inline nn::Result
+GetCloseStatus()
+{
+   return detail::GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status();
 }
 
 /**

--- a/include/nsysnet/socket.h
+++ b/include/nsysnet/socket.h
@@ -19,18 +19,6 @@ extern "C" {
 #define NSN_EWOULDBLOCK     EWOULDBLOCK
 
 __attribute__ ((deprecated))
-static inline void
-socket_lib_init()
-{
-}
-
-__attribute__ ((deprecated))
-static inline void
-socket_lib_finish()
-{
-}
-
-__attribute__ ((deprecated))
 static inline int
 socketclose(int sockfd)
 {

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -69,6 +69,14 @@ struct linger
 extern "C" {
 #endif
 
+// Wii U "extension"
+void
+socket_lib_init();
+
+// Wii U "extension"
+void
+socket_lib_finish();
+
 int
 accept(int sockfd,
        struct sockaddr *addr,

--- a/libraries/libwhb/src/libmanager.c
+++ b/libraries/libwhb/src/libmanager.c
@@ -1,9 +1,0 @@
-void
-WHBInitializeSocketLibrary()
-{
-}
-
-void
-WHBDeinitializeSocketLibrary()
-{
-}

--- a/libraries/libwhb/src/log_udp.c
+++ b/libraries/libwhb/src/log_udp.c
@@ -6,7 +6,6 @@
 #include <string.h>
 #include <whb/log.h>
 #include <whb/log_udp.h>
-#include <whb/libmanager.h>
 
 static int
 sSocket = -1;
@@ -31,6 +30,7 @@ BOOL
 WHBLogUdpInit()
 {
    int broadcastEnable = 1;
+   socket_lib_init();
 
    sSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
    if (sSocket < 0) {
@@ -54,5 +54,6 @@ WHBLogUdpDeinit()
       return FALSE;
    }
 
+   socket_lib_finish();
    return WHBRemoveLogHandler(udpLogHandler);
 }

--- a/libraries/wutsocket/wut_socket_common.c
+++ b/libraries/wutsocket/wut_socket_common.c
@@ -104,12 +104,13 @@ __init_wut_socket()
 {
    socket_lib_init();
    ACInitialize();
-   ACConnect();
+   ACConnectAsync();
 }
 
 void __attribute__((weak))
 __fini_wut_socket()
 {
+   ACClose();
    ACFinalize();
    socket_lib_finish();
 }


### PR DESCRIPTION
- Add missing ACClose() + ACGetCloseStatus().
- Apparently ACConnect() is blocking (for up to ~40 seconds) if the default connection is via LAN but no cable is connected. Changing it to ACConnectAsync() fixes this.
- Add some missing definitions in ac_cpp.h

Update (01.05.2021):
- added `__wut_socket_init_devoptab` and `__wut_socket_fini_devoptab` to be able to have a custom `__init_wut_socket` implementation that still uses the wut socket devoptab.
- Reverted the `socket_lib_init`/`socket_lib_finish` wrapper because it's not needed anymore. Normal homebrews will init the devoptab via CRT0, in case of plugin/modules this will handled by the Module/Plugin-System. 