### PR TITLE
Add missing __libc_init_array and __libc_fini_array calls

### DIFF
--- a/libraries/wutcrt/wut_crt.c
+++ b/libraries/wutcrt/wut_crt.c
@@ -3,12 +3,17 @@ void __init_wut_newlib();
 void __init_wut_stdcpp();
 void __init_wut_devoptab();
 void __attribute__((weak)) __init_wut_socket();
+void __libc_init_array(void);
 
 void __fini_wut_malloc();
 void __fini_wut_newlib();
 void __fini_wut_stdcpp();
 void __fini_wut_devoptab();
 void __attribute__((weak)) __fini_wut_socket();
+void __libc_fini_array(void);
+
+void
+_init(void) { }
 
 void __attribute__((weak))
 __init_wut()
@@ -18,11 +23,16 @@ __init_wut()
    __init_wut_stdcpp();
    __init_wut_devoptab();
    if (&__init_wut_socket) __init_wut_socket();
+   __libc_init_array();
 }
+
+void
+_fini(void) { }
 
 void __attribute__((weak))
 __fini_wut()
 {
+   __libc_fini_array();
    if (&__fini_wut_socket) __fini_wut_socket();
    __fini_wut_devoptab();
    __fini_wut_stdcpp();


### PR DESCRIPTION
Needed for static C++ constructors to be called before main.

`__libc_init_array` will call `_init` and `__libc_fini_array` will call `_fini` so these need to be implemented as well. I just put them into `wut_crt.c` for now. 