### PR TITLE
Improve KPAD function signatures, and small updates to VPAD functions

### DIFF
--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -242,7 +242,7 @@ KPADShutdown();
  * \return
  * The number of data read.
  */
-int32_t
+uint32_t
 KPADRead(KPADChan chan,
          KPADStatus *data,
          uint32_t size);
@@ -265,7 +265,7 @@ KPADRead(KPADChan chan,
  * \return
  * The number of data read.
  */
-int32_t
+uint32_t
 KPADReadEx(KPADChan chan,
            KPADStatus *data,
            uint32_t size,

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -212,6 +212,12 @@ void
 KPADInit();
 
 /**
+ * Cleans up and frees the KPAD library.
+ */
+void
+KPADShutdown();
+
+/**
  * Read data from the desired Wii Remote.
  *
  * \param chan

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -26,11 +26,21 @@ typedef struct KPADVec2D KPADVec2D;
 typedef struct KPADVec3D KPADVec3D;
 
 //! Error.
-typedef enum KPADError
+typedef enum KPADReadError
 {
-   //! No errors.
-   KPAD_ERROR_OK              = 0,
-} KPADError;
+    //! No error occurred, and data was written to the buffers.
+    KPAD_READ_SUCCESS             = 0,
+    //! There was no sample new data available to write.
+    KPAD_READ_NO_SAMPLES          = -1,
+    //! The requested controller or channel was invalid.
+    KPAD_READ_INVALID_CONTROLLER  = -2,
+    //! WPAD is uninitialized, shouldn't happen unless WPADShutdown() is manually called
+    KPAD_READ_WPAD_UNINIT         = -3,
+    //! KPAD channel is busy, perhaps being accessed by another thread
+    KPAD_READ_BUSY                = -4,
+    //! KPAD is uninitialized, need to call KPADInit()
+    KPAD_READ_UNINITIALIZED       = -5,
+} KPADReadError;
 
 //! 2D vector.
 struct KPADVec2D
@@ -259,7 +269,7 @@ int32_t
 KPADReadEx(KPADChan chan,
            KPADStatus *data,
            uint32_t size,
-           int32_t *error);
+           KPADReadError *error);
 
 #ifdef __cplusplus
 }

--- a/include/vpad/input.h
+++ b/include/vpad/input.h
@@ -372,12 +372,12 @@ VPADShutdown();
  * or invalid data on error, not necessarily zeroes.
  *
  * \return
- * 0 on success or 1 on failure. Check outError for reason.
+ * The number of data read.
  *
  * \sa
  * - VPADStatus
  */
-int32_t
+uint32_t
 VPADRead(VPADChan chan,
          VPADStatus *buffers,
          uint32_t count,

--- a/include/vpad/input.h
+++ b/include/vpad/input.h
@@ -119,6 +119,10 @@ typedef enum VPADReadError
    VPAD_READ_NO_SAMPLES          = -1,
    //! The requested controller or channel was invalid.
    VPAD_READ_INVALID_CONTROLLER  = -2,
+   //! VPAD channel is busy, perhaps being accessed by another thread
+   VPAD_READ_BUSY                = -4,
+   //! VPAD is uninitialized, need to call VPADInit()
+   VPAD_READ_UNINITIALIZED       = -5,
 } VPADReadError;
 
 //! LCD mode.


### PR DESCRIPTION
This is a number of changes focused primarily on the KPAD interface, but includes some changes for VPAD when the changes also applied to them. This does result in some amount of API compatibility breaks, but I think the improved consistency is worth it.

The first change is simply adding a function signature for `KPADShutdown()`. I'm not sure why this wasn't present, considering that `KPADInit()` is already there, but adding this is a simple, non-breaking but important addition.

The second change is adding more error codes for both KPAD and VPAD, as well as changing the existing error enum for KPAD to be more consistent with how VPAD labels the errors. I took a look at the disassembly of both `KPADReadEx` and `VPADRead` to figure out what all the possible error codes are and make educated guesses as to what the errors indicate. It definitely appears that they share the same error codes, as they both result in error codes in similar locations in their respective read functions, and VPAD has a gap in the possible error codes (`-3` is never returned). With that in mind, I renamed the existing `KPADError` and it's one existing value to match the error enum for VPAD. This, along with using the enum type in the function signature for `KPADReadEx`, are API breaks, but I think this is still worth it due to how minimal the existing KPAD error enum was previously.

Lastly, I changed the return types for `KPADRead`, `KPADReadEx`, and `VPADRead` from `int32_t` to `uint32_t`, as well as updated the comment explaining `VPADRead`'s return value, since it was incorrect. The return value from these functions is the number of entries actually written to the output buffer. Since the functions have an argument with the length of this buffer, it makes sense to have these types match, but they currently don't. Between making the return type unsigned or the argument type signed, I figured the former made the most sense (as it's a case where I'd use `size_t`, which is equivalent to `uint32_t` on the Wii U). This is another API break, but may be harder to justify. If you don't think this change is worth it, I can drop the commit from this PR, but I think it's better to make this change now than to just leave it.