### PR TITLE
Add OSForceFullRelaunch() declaration

### DIFF
--- a/include/coreinit/launch.h
+++ b/include/coreinit/launch.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup coreinit_launch Launch
+ * \ingroup coreinit
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void
+OSForceFullRelaunch();
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
This one is pretty simple. `OSForceFullRelaunch()` followed by `SYSLaunchMenu()` is a common function pairing from what I can tell. For example, the Haxchi installer calls this pair of functions just before closing if a title has been patched. `SYSLaunchMenu()` is already declared in include/sysapp/launch.h, so `OSForceFullRelaunch()` should probably be included as well.

I wasn't sure where best to add this function. I knew it should go somewhere in include/coreinit, but I couldn't find an appropriate file to add it to. In the end, I opted to add it to a new header file on its own for now, as that seemed like the best option. If there's a better place to put this, let me know and I can update this.