### PR TITLE
Add support for a upcoming LoggingModule

### DIFF
--- a/libraries/libwhb/include/whb/log_module.h
+++ b/libraries/libwhb/include/whb/log_module.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup whb_log_module Log using the LoggingModule.
+ * \ingroup whb
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+BOOL
+WHBLogModuleInit();
+
+BOOL
+WHBLogModuleDeinit();
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/libraries/libwhb/src/log.c
+++ b/libraries/libwhb/src/log.c
@@ -28,7 +28,7 @@ WHBAddLogHandler(LogHandlerFn fn)
 
    for (i = 0; i < MAX_HANDLERS; ++i) {
       if(sHandlers[i] == fn){
-        break;
+        return TRUE;
       }
       if (!sHandlers[i]) {
          sHandlers[i] = fn;

--- a/libraries/libwhb/src/log_module.c
+++ b/libraries/libwhb/src/log_module.c
@@ -1,0 +1,37 @@
+#include <coreinit/dynload.h>
+#include <coreinit/debug.h>
+#include <whb/log.h>
+#include <string.h>
+
+static OSDynLoad_Module sModuleHandle = NULL;
+static void (*sWUMSLogWrite)(const char *, size_t) = NULL;
+
+static void
+moduleLogHandler(const char *msg)
+{
+   if(sWUMSLogWrite != NULL) {
+      sWUMSLogWrite(msg, strlen(msg));
+   }
+}
+
+BOOL
+WHBLogModuleInit()
+{   
+   if (OSDynLoad_Acquire("homebrew_logging", &sModuleHandle) != OS_DYNLOAD_OK) {
+      OSReport("WHBLogModuleInit: OSDynLoad_Acquire failed.\n");
+      return false;
+   }
+
+   if (OSDynLoad_FindExport(sModuleHandle, FALSE, "WUMSLogWrite", (void**) &sWUMSLogWrite) != OS_DYNLOAD_OK) {
+      OSReport("WHBLogModuleInit: OSDynLoad_FindExport failed.\n");
+      return false;
+   }
+
+   return WHBAddLogHandler(moduleLogHandler);
+}
+
+BOOL
+WHBLogModuleDeinit()
+{
+   return WHBRemoveLogHandler(moduleLogHandler);
+}


### PR DESCRIPTION
Aroma will have  the concepts of "modules" will can exports functions like system rpls do.  There will be a module for logging and this PR is implementing support for it.

Advantages of outsourcing the actual logging implementation into a module:
- Can be updated/replaced without recompiling every homebrew
- In combination of a plugin it would be even possible to have some runtime implementation
- This avoids that every homebrew/module/plugins will need to bring they own logging implementation (e.g. via udp), which reduces filesizes. (simple modules which used `WHBLogUdpInit()` are now 5KiB instead of 45KiB)

Recommended usage:
Currently Aroma is not release and there are use cases where Aroma (and so also the LoggingModule) is simply not available. If this a possible scenario for the homebrew its recommened to fallback into another logging method like this:
```
if(!WHBLogModuleInit()){
    // If the logging module is not avaible use something different
    // e.g. WHBLogUdpInit(); or WHBLogCafeInit();
}
```

This PR also includes a fix for the `WHBAddLogHandler` to return TRUE if you try to add a loghandler which was already added before to allows this fallback behaviour.