### PR TITLE
libwhb: Rename render-related functions to be less ambiguous

### DIFF
--- a/libraries/libwhb/include/whb/gfx.h
+++ b/libraries/libwhb/include/whb/gfx.h
@@ -32,26 +32,92 @@ WHBGfxInit();
 void
 WHBGfxShutdown();
 
-void
-WHBGfxBeginRender();
+BOOL
+WHBGfxWaitForSwap();
 
+BOOL
+WHBGfxSwapScanBuffers();
+
+WUT_DEPRECATED("Do not use WHBGfxBeginRender and WHBGfxFinishRender. "  \
+               "Use WHBGfxSwapScanBuffers at end of the frame instead.")
+inline void
+WHBGfxBeginRender()
+{
+    WHBGfxWaitForSwap();
+}
+
+WUT_DEPRECATED("Do not use WHBGfxBeginRender and WHBGfxFinishRender. "  \
+               "Use WHBGfxSwapScanBuffers at end of the frame instead.")
 void
 WHBGfxFinishRender();
 
 void
-WHBGfxClearColor(float r, float g, float b, float a);
+WHBGfxClearColorOnly(float r, float g, float b, float a);
 
 void
-WHBGfxBeginRenderDRC();
+WHBGfxClearDepthStencil();
 
 void
-WHBGfxFinishRenderDRC();
+WHBGfxClearColorDepthStencil(float r, float g, float b, float a);
+
+WUT_DEPRECATED("Use WHBGfxClearColorDepthStencil instead.")
+inline void
+WHBGfxClearColor(float r, float g, float b, float a)
+{
+    WHBGfxClearColorDepthStencil(r, g, b, a);
+}
 
 void
-WHBGfxBeginRenderTV();
+WHBGfxMakeDRCContextCurrent();
 
 void
-WHBGfxFinishRenderTV();
+WHBGfxCopyDRCColorBufferTo(GX2ScanTarget scanBuffer);
+
+inline void
+WHBGfxCopyDRCColorBufferToDRCScanBuffer()
+{
+    WHBGfxCopyDRCColorBufferTo(GX2_SCAN_TARGET_DRC);
+}
+
+void
+WHBGfxMakeTVContextCurrent();
+
+void
+WHBGfxCopyTVColorBufferTo(GX2ScanTarget scanBuffer);
+
+inline void
+WHBGfxCopyTVColorBufferToTVScanBuffer()
+{
+    WHBGfxCopyTVColorBufferTo(GX2_SCAN_TARGET_TV);
+}
+
+WUT_DEPRECATED("Use WHBGfxMakeDRCContextCurrent instead.")
+inline void
+WHBGfxBeginRenderDRC()
+{
+    WHBGfxMakeDRCContextCurrent();
+}
+
+WUT_DEPRECATED("Use WHBGfxCopyDRCColorBufferToDRCScanBuffer instead.")
+inline void
+WHBGfxFinishRenderDRC()
+{
+    WHBGfxCopyDRCColorBufferToDRCScanBuffer();
+}
+
+WUT_DEPRECATED("Use WHBGfxMakeTVContextCurrent instead.")
+inline void
+WHBGfxBeginRenderTV()
+{
+    WHBGfxMakeTVContextCurrent();
+}
+
+WUT_DEPRECATED("Use WHBGfxCopyTVColorBufferToTVScanBuffer instead.")
+inline void
+WHBGfxFinishRenderTV()
+{
+    WHBGfxCopyTVColorBufferToTVScanBuffer();
+}
 
 GX2PixelShader *
 WHBGfxLoadGFDPixelShader(uint32_t index,

--- a/samples/cmake/gx2_triangle/main.c
+++ b/samples/cmake/gx2_triangle/main.c
@@ -120,29 +120,38 @@ int main(int argc, char **argv)
       GX2RUnlockBufferEx(&colourBuffer, 0);
 
       // Render!
-      WHBGfxBeginRender();
 
-      WHBGfxBeginRenderTV();
-      WHBGfxClearColor(0.0f, 0.0f, 1.0f, 1.0f);
-      GX2SetFetchShader(&group.fetchShader);
-      GX2SetVertexShader(group.vertexShader);
-      GX2SetPixelShader(group.pixelShader);
-      GX2RSetAttributeBuffer(&positionBuffer, 0, positionBuffer.elemSize, 0);
-      GX2RSetAttributeBuffer(&colourBuffer, 1, colourBuffer.elemSize, 0);
-      GX2DrawEx(GX2_PRIMITIVE_MODE_TRIANGLES, 3, 0, 1);
-      WHBGfxFinishRenderTV();
+      WHBGfxMakeTVContextCurrent();
+      {
+         WHBGfxClearColorDepthStencil(0.0f, 0.0f, 1.0f, 1.0f);
 
-      WHBGfxBeginRenderDRC();
-      WHBGfxClearColor(1.0f, 0.0f, 1.0f, 1.0f);
-      GX2SetFetchShader(&group.fetchShader);
-      GX2SetVertexShader(group.vertexShader);
-      GX2SetPixelShader(group.pixelShader);
-      GX2RSetAttributeBuffer(&positionBuffer, 0, positionBuffer.elemSize, 0);
-      GX2RSetAttributeBuffer(&colourBuffer, 1, colourBuffer.elemSize, 0);
-      GX2DrawEx(GX2_PRIMITIVE_MODE_TRIANGLES, 3, 0, 1);
-      WHBGfxFinishRenderDRC();
+         GX2SetFetchShader(&group.fetchShader);
+         GX2SetVertexShader(group.vertexShader);
+         GX2SetPixelShader(group.pixelShader);
 
-      WHBGfxFinishRender();
+         GX2RSetAttributeBuffer(&positionBuffer, 0, positionBuffer.elemSize, 0);
+         GX2RSetAttributeBuffer(&colourBuffer, 1, colourBuffer.elemSize, 0);
+
+         GX2DrawEx(GX2_PRIMITIVE_MODE_TRIANGLES, 3, 0, 1);
+      }
+
+      WHBGfxMakeDRCContextCurrent();
+      {
+         WHBGfxClearColorDepthStencil(1.0f, 0.0f, 1.0f, 1.0f);
+
+         GX2SetFetchShader(&group.fetchShader);
+         GX2SetVertexShader(group.vertexShader);
+         GX2SetPixelShader(group.pixelShader);
+
+         GX2RSetAttributeBuffer(&positionBuffer, 0, positionBuffer.elemSize, 0);
+         GX2RSetAttributeBuffer(&colourBuffer, 1, colourBuffer.elemSize, 0);
+
+         GX2DrawEx(GX2_PRIMITIVE_MODE_TRIANGLES, 3, 0, 1);
+      }
+
+      WHBGfxCopyTVColorBufferToTVScanBuffer();
+      WHBGfxCopyDRCColorBufferToDRCScanBuffer();
+      WHBGfxSwapScanBuffers();
    }
 
 exit:

--- a/samples/cmake/swkbd/main.cpp
+++ b/samples/cmake/swkbd/main.cpp
@@ -69,19 +69,21 @@ int main(int argc, char **argv)
          break;
       }
 
-      WHBGfxBeginRender();
+      WHBGfxMakeTVContextCurrent();
+      {
+         WHBGfxClearColorDepthStencil(0.0f, 0.0f, 1.0f, 1.0f);
+         nn::swkbd::DrawTV();
+      }
 
-      WHBGfxBeginRenderTV();
-      WHBGfxClearColor(0.0f, 0.0f, 1.0f, 1.0f);
-      nn::swkbd::DrawTV();
-      WHBGfxFinishRenderTV();
+      WHBGfxMakeDRCContextCurrent();
+      {
+         WHBGfxClearColorDepthStencil(1.0f, 0.0f, 1.0f, 1.0f);
+         nn::swkbd::DrawDRC();
+      }
 
-      WHBGfxBeginRenderDRC();
-      WHBGfxClearColor(1.0f, 0.0f, 1.0f, 1.0f);
-      nn::swkbd::DrawDRC();
-      WHBGfxFinishRenderDRC();
-
-      WHBGfxFinishRender();
+      WHBGfxCopyTVColorBufferToTVScanBuffer();
+      WHBGfxCopyDRCColorBufferToDRCScanBuffer();
+      WHBGfxSwapScanBuffers();
    }
 
    const char16_t *str = nn::swkbd::GetInputFormString();


### PR DESCRIPTION
I renamed the following functions so that it's more obvious what they do:
- WHBGfxBeginRender -> WHBGfxWaitForSwap
- WHBGfxFinishRender -> WHBGfxSwapScanBuffers (automatically calls WHBGfxWaitForSwap)
- WHBGfxClearColor -> WHBGfxClearColorDepthStencil (this is what the function actually does)
- WHBGfxBeginRender{DRC/TV} -> WHBGfxMake{DRC/TV}ContextCurrent
- WHBGfxFinishRender{DRC/TV} -> WHBGfxCopy{DRC/TV}ColorBufferTo{DRC/TV}ScanBuffer

Since these existed for a long time, I deprecated them instead of removing them to retain compatibility with existing homebrew.

I also added the following functions for convenience:
- WHBGfxClearColorOnly (this should have been the real WHBGfxClearColor)
- WHBGfxClearDepthStencil
- WHBCopyTVColorBufferTo (useful for duplicating TV output to DRC/Gamepad)
- WHBCopyDRCColorBufferTo (^^^)