### PR TITLE
coreinit: Fix OSThreadLink struct

### DIFF
--- a/include/coreinit/threadqueue.h
+++ b/include/coreinit/threadqueue.h
@@ -19,11 +19,11 @@ typedef struct OSThreadSimpleQueue OSThreadSimpleQueue;
 
 struct OSThreadLink
 {
-   OSThread *prev;
    OSThread *next;
+   OSThread *prev;
 };
-WUT_CHECK_OFFSET(OSThreadLink, 0x00, prev);
-WUT_CHECK_OFFSET(OSThreadLink, 0x04, next);
+WUT_CHECK_OFFSET(OSThreadLink, 0x00, next);
+WUT_CHECK_OFFSET(OSThreadLink, 0x04, prev);
 WUT_CHECK_SIZE(OSThreadLink, 0x8);
 
 struct OSThreadQueue


### PR DESCRIPTION
`next` and `prev` were swapped for some reason, see [decaf](https://github.com/decaf-emu/decaf-emu/blob/6feb1be1db3938e6da2d4a65fc0a7a8599fc8dd6/src/libdecaf/src/cafe/libraries/coreinit/coreinit_thread.h#L74)
