### PR TITLE
sysapp: Fix return types and arguments for switchTo-functions, add missing switchTo-fucntions

### DIFF
--- a/include/sysapp/switch.h
+++ b/include/sysapp/switch.h
@@ -19,8 +19,82 @@
 extern "C" {
 #endif
 
-//! Argument struct for \link SYSSwitchToBrowserForViewer \endlink.
+typedef struct SysAppStandardArgs SysAppStandardArgs;
 typedef struct SysAppBrowserArgs SysAppBrowserArgs;
+typedef struct SysAppBrowserArgsWithCallback SysAppBrowserArgsWithCallback;
+typedef struct SysAppEShopArgs SysAppEShopArgs;
+typedef struct SysAppEManualArgs SysAppEManualArgs;
+
+struct SysAppStandardArgs
+{
+    void *anchor;
+    uint32_t anchorSize;
+};
+WUT_CHECK_OFFSET(SysAppStandardArgs, 0x0, anchor);
+WUT_CHECK_OFFSET(SysAppStandardArgs, 0x4, anchorSize);
+WUT_CHECK_SIZE(SysAppStandardArgs, 0x8);
+
+struct SysAppEManualArgs
+{
+    SysAppStandardArgs stdArgs;
+    uint64_t titleId;
+};
+WUT_CHECK_OFFSET(SysAppEManualArgs, 0x0, stdArgs);
+WUT_CHECK_OFFSET(SysAppEManualArgs, 0x8, titleId);
+WUT_CHECK_SIZE(SysAppEManualArgs, 0x10);
+
+struct SysAppEShopArgs
+{
+    SysAppStandardArgs stdArgs;
+    char *query;
+    uint32_t querySize;
+};
+WUT_CHECK_OFFSET(SysAppEShopArgs, 0x0, stdArgs);
+WUT_CHECK_OFFSET(SysAppEShopArgs, 0x8, query);
+WUT_CHECK_OFFSET(SysAppEShopArgs, 0xc, querySize);
+WUT_CHECK_SIZE(SysAppEShopArgs, 0x10);
+
+struct SysAppBrowserArgs
+{
+    SysAppStandardArgs stdArgs;
+    char *url;    
+    uint32_t urlSize;    
+};
+WUT_CHECK_OFFSET(SysAppBrowserArgs, 0x0, stdArgs);
+WUT_CHECK_OFFSET(SysAppBrowserArgs, 0x8, url);
+WUT_CHECK_OFFSET(SysAppBrowserArgs, 0xC, urlSize);
+WUT_CHECK_SIZE(SysAppBrowserArgs, 0x10);
+
+struct SysAppBrowserArgsWithCallback
+{
+    SysAppBrowserArgs browserArgs;
+    char *cbUrl;
+    uint32_t cbUrlSize; 
+    BOOL hbmDisable; 
+};
+WUT_CHECK_OFFSET(SysAppBrowserArgsWithCallback, 0x0, browserArgs);
+WUT_CHECK_OFFSET(SysAppBrowserArgsWithCallback, 0x10, cbUrl);
+WUT_CHECK_OFFSET(SysAppBrowserArgsWithCallback, 0x14, cbUrlSize);
+WUT_CHECK_OFFSET(SysAppBrowserArgsWithCallback, 0x18, hbmDisable);
+WUT_CHECK_SIZE(SysAppBrowserArgsWithCallback, 0x1C);
+
+typedef enum SysAppPFID
+{   
+   SYSAPP_PFID_WII_U_MENU          = 2,
+   SYSAPP_PFID_TVII                = 3,
+   SYSAPP_PFID_EMANUAL             = 4,
+   SYSAPP_PFID_HOME_MENU           = 5,
+   SYSAPP_PFID_MINI_MIIVERSE       = 7,
+   SYSAPP_PFID_BROWSER             = 8,
+   SYSAPP_PFID_MIIVERSE            = 9,
+   SYSAPP_PFID_ESHOP               = 10,
+   SYSAPP_PFID_FRIENDLIST          = 11,
+   SYSAPP_PFID_DOWNLOAD_MANAGEMENT = 12,
+   SYSAPP_PFID_DOWNLOAD_GAME       = 15,
+   SYSAPP_PFID_MINTU               = 16,
+   SYSAPP_PFID_CABINETU            = 17,
+   SYSAPP_PFID_TEST_OVERLAY        = 31,
+} SysAppPFID;
 
 /**
  * Initiate a switch into the controller sync menu. This is the same menu
@@ -30,7 +104,7 @@ typedef struct SysAppBrowserArgs SysAppBrowserArgs;
  * proc_ui_procui ProcUI\endlink) and the sync menu is shown. Once the user
  * exits the menu, the application is moved back to the foreground.
  */
-void
+int32_t
 SYSSwitchToSyncControllerOnHBM();
 
 /**
@@ -40,8 +114,14 @@ SYSSwitchToSyncControllerOnHBM();
  * proc_ui_procui ProcUI\endlink) and the e-manual is shown. Once the user
  * exits the menu, the application is moved back to the foreground.
  */
-void
+int32_t
 SYSSwitchToEManual();
+
+int32_t
+_SYSSwitchToEManual(SysAppEManualArgs *);
+
+int32_t
+_SYSSwitchToEManualFromHBM(SysAppEManualArgs *);
 
 /**
  * Initiate a switch to the Nintendo eShop application.
@@ -50,8 +130,14 @@ SYSSwitchToEManual();
  * proc_ui_procui ProcUI\endlink) and the Nintendo eShop is shown. Once the user
  * exits the menu, the application is moved back to the foreground.
  */
-void
-SYSSwitchToEShop();
+int32_t
+SYSSwitchToEShop(SysAppEShopArgs *);
+
+int32_t
+SYSSwitchToEShopTicketList(SysAppStandardArgs *);
+
+int32_t
+_SYSSwitchToEShopFromHBM(SysAppEShopArgs *);
 
 /**
  * <!--
@@ -60,19 +146,43 @@ SYSSwitchToEShop();
  *    Presumably meant for overlay apps to exit?
  * -->
  */
-void
+int32_t
 _SYSSwitchToMainApp();
+
+int32_t
+SYSSwitchToBrowser(SysAppBrowserArgs *);
 
 /**
  * Initiates a switch to the Internet Browser application, with the given
- * arguments in the form of a \link SysAppBrowserArgs \endlink struct.
+ * arguments in the form of a \link SysBrowserArgsIn \endlink struct.
  *
  * The current application is moved into the background (see \link
  * proc_ui_procui ProcUI\endlink) and the Internet Browser is shown. Once the
  * user exits the menu, the application is moved back to the foreground.
  */
-void
+int32_t
 SYSSwitchToBrowserForViewer(SysAppBrowserArgs *);
+
+int32_t
+SYSSwitchToBrowserForCallbackURL(SysAppBrowserArgsWithCallback *);
+
+int32_t
+_SYSSwitchToBrowserForCallbackURLFromHBM(SysAppBrowserArgsWithCallback *);
+
+int32_t
+_SYSSwitchToHBMWithMode(int32_t);
+
+int32_t
+_SYSSwitchToOverlayFromHBM(int32_t);
+
+/**
+ * Calls __OSClearCopyData then _SYSSwitchTo
+ */
+int32_t 
+SYSSwitchTo(SysAppPFID pfid);
+
+int32_t 
+_SYSSwitchTo(SysAppPFID pfid);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Add missing return types (probably >= 0 on success)
- Add missing arguments for existing functions
- Complete incomplete types
- Add missing functions
- add missing types