### PR TITLE
wutdevoptab: Only call FSUnmount if FSMount was successful

### DIFF
--- a/libraries/wutdevoptab/devoptab_fs.c
+++ b/libraries/wutdevoptab/devoptab_fs.c
@@ -37,6 +37,9 @@ __wut_devoptab_fs_client = NULL;
 static BOOL
 __wut_fs_initialised = FALSE;
 
+static BOOL
+__wut_sd_mounted = FALSE;
+
 static char
 sMountPath[0x80];
 
@@ -81,6 +84,7 @@ __init_wut_devoptab()
          rc = FSMount(__wut_devoptab_fs_client, &fsCmd, &mountSource, sMountPath, sizeof(sMountPath), FS_ERROR_FLAG_ALL);
 
          if (rc >= 0) {
+            __wut_sd_mounted = TRUE;
             // chdir to SD root for general use
             strcpy(workDir, "fs:");
             strcat(workDir, sMountPath);
@@ -106,17 +110,19 @@ __fini_wut_devoptab()
    }
 
    FSCmdBlock fsCmd;
-   FSInitCmdBlock(&fsCmd);
-
-   FSUnmount(__wut_devoptab_fs_client, &fsCmd, sMountPath, FS_ERROR_FLAG_ALL);
+   if(__wut_sd_mounted) {
+      FSInitCmdBlock(&fsCmd);
+      FSUnmount(__wut_devoptab_fs_client, &fsCmd, sMountPath, FS_ERROR_FLAG_ALL);
+      __wut_sd_mounted = FALSE;
+   }
 
    FSDelClient(__wut_devoptab_fs_client, FS_ERROR_FLAG_ALL);
    free(__wut_devoptab_fs_client);
-   
+
    RemoveDevice(__wut_fs_devoptab.name);
-   
-   __wut_devoptab_fs_client = NULL;   
+
+   __wut_devoptab_fs_client = NULL;
    __wut_fs_initialised = FALSE;
-   
+
    return rc;
 }


### PR DESCRIPTION
We need to make sure FSUnmount is only called with a valid target. Calling FSUnmount with an invalid target causes the FS to throw fatal error, softlocking the whole console:

```
00;02;09;520: FS: FSUnmount: target specifies invalid mount path.
00;02;09;520: FS: Updated volume state of client 0x80cfbd80 to FS_VOLSTATE_FATAL(10)
00;02;09;520: FS: by error -196641.
00;02;09;520: FS: Fatal error occured.
```