### PR TITLE
wutdevoptab: Replace FSError usage with FSStatus in __wut_fs_translate_error

### DIFF
--- a/libraries/wutdevoptab/devoptab_fs_mkdir.c
+++ b/libraries/wutdevoptab/devoptab_fs_mkdir.c
@@ -5,7 +5,7 @@ __wut_fs_mkdir(struct _reent *r,
                const char *path,
                int mode)
 {
-   FSError status;
+   FSStatus status;
    FSCmdBlock cmd;
    char *fixedPath;
 

--- a/libraries/wutdevoptab/devoptab_fs_utils.c
+++ b/libraries/wutdevoptab/devoptab_fs_utils.c
@@ -36,11 +36,11 @@ __wut_fs_fixpath(struct _reent *r,
 int
 __wut_fs_translate_error(FSStatus error)
 {
-   switch ((int32_t)error) {
+   switch ((int)error) {
    case FS_STATUS_END:
       return ENOENT;
    case FS_STATUS_CANCELLED:
-      return EINVAL;
+      return ECANCELED;
    case FS_STATUS_EXISTS:
       return EEXIST;
    case FS_STATUS_MEDIA_ERROR:
@@ -51,27 +51,26 @@ __wut_fs_translate_error(FSStatus error)
       return EPERM;
    case FS_STATUS_STORAGE_FULL:
       return ENOSPC;
-   case FS_ERROR_ALREADY_EXISTS:
-      return EEXIST;
-   case FS_ERROR_BUSY:
-      return EBUSY;
-   case FS_ERROR_CANCELLED:
-      return ECANCELED;
    case FS_STATUS_FILE_TOO_BIG:
       return EFBIG;
-   case FS_ERROR_INVALID_PATH:
-      return ENAMETOOLONG;
-   case FS_ERROR_NOT_DIR:
+   case FS_STATUS_NOT_DIR:
       return ENOTDIR;
-   case FS_ERROR_NOT_FILE:
+   case FS_STATUS_NOT_FILE:
       return EISDIR;
-   case FS_ERROR_OUT_OF_RANGE:
-      return ESPIPE;
-   case FS_ERROR_UNSUPPORTED_COMMAND:
+   case FS_STATUS_MAX:
+      return ENFILE;
+   case FS_STATUS_ACCESS_ERROR:
+      return EACCES;
+   case FS_STATUS_JOURNAL_FULL:
+      return ENOSPC;
+   case FS_STATUS_UNSUPPORTED_CMD:
       return ENOTSUP;
-   case FS_ERROR_WRITE_PROTECTED:
-      return EROFS;
-   default:
-      return (int)error;
+   case FS_STATUS_MEDIA_NOT_READY:
+      return EOWNERDEAD;
+   case FS_STATUS_ALREADY_OPEN:
+   case FS_STATUS_CORRUPTED:
+   case FS_STATUS_FATAL_ERROR:
+      return EIO;
    }
+   return (int)error;
 }


### PR DESCRIPTION
The FSError values are only used for `FSSetEmulatedError` and `FSGetEmulatedError` to emulate fs errors (and interally in the FSClient struct). 

**No FS function is ever returning FSError values.** 

This PR removes the mapping for all FSError values, fixes the `FS_STATUS_CANCELLED` mapping, and add the mapping for the missing FSStatus values.
I couldn't find a matching value for FS_STATUS_ALREADY_OPEN, FS_STATUS_CORRUPTED and FS_STATUS_FATAL_ERROR so I decided to return EIO, not sure if there is a better option
