### PR TITLE
Fix syscall_clock* implementation

### DIFF
--- a/libraries/wutnewlib/wut_newlib.c
+++ b/libraries/wutnewlib/wut_newlib.c
@@ -5,7 +5,7 @@ void(*__wut_exit)(int rc);
 extern void __fini_wut(void);
 
 int __syscall_lock_init(int *lock, int recursive) {
-  return __wut_lock_init(lock,recursive);
+  return __wut_lock_init(lock, recursive);
 }
 
 int __syscall_lock_close(int *lock) {
@@ -25,14 +25,25 @@ void __syscall_exit(int rc) {
   __wut_exit(rc);
 }
 
-int  __syscall_gettod_r(struct _reent *ptr, struct timeval *tp, struct timezone *tz){
-  return __wut_gettod_r(ptr,tp,tz);
+int  __syscall_gettod_r(struct _reent *ptr, struct timeval *tp, struct timezone *tz) {
+  return __wut_gettod_r(ptr, tp, tz);
 }
 
-int __syscall_nanosleep(const struct timespec *req, struct timespec *rem){
+int __syscall_nanosleep(const struct timespec *req, struct timespec *rem) {
   return __wut_nanosleep(req, rem);
 }
 
+int __syscall_clock_gettime(clockid_t clock_id, struct timespec *tp) {
+  return __wut_clock_gettime(clock_id, tp);
+}
+
+int __syscall_clock_settime(clockid_t clock_id, const struct timespec *tp) {
+   return __wut_clock_settime(clock_id, tp);
+}
+
+int __syscall_clock_getres(clockid_t clock_id, struct timespec *res) {
+   return __wut_clock_getres(clock_id, res);
+}
 
 void
 __init_wut_newlib()


### PR DESCRIPTION
Fixes for example usage of `std::chrono::high_resolution_clock::now()`