### PR TITLE
nn_acp: Add ACPMetaXml parameter alignment check

### DIFF
--- a/cafe/nn_acp.def
+++ b/cafe/nn_acp.def
@@ -71,7 +71,6 @@ ACPGetTitleInfoOfMainApplication
 ACPGetTitleMetaDir
 ACPGetTitleMetaDirByDevice
 ACPGetTitleMetaDirByTitleListType
-ACPGetTitleMetaXml
 ACPGetTitleMetaXmlByDevice
 ACPGetTitleMetaXmlByPath
 ACPGetTitleMetaXmlByTitleListType
@@ -159,3 +158,6 @@ TurnOffDrcLed__Q2_2nn3acpFv
 TurnOnDrcLedTest__Q2_2nn3acpFUcUiQ3_2nn3acp13DrcLedPattern
 TurnOnDrcLed__Q2_2nn3acpFUiQ3_2nn3acp13DrcLedPattern
 WaitExternalStorage__Q2_2nn3acpFv
+
+:TEXT_WRAP
+ACPGetTitleMetaXml

--- a/include/nn/acp/title.h
+++ b/include/nn/acp/title.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <wut.h>
 #include <nn/acp/result.h>
 #include <nn/acp/device.h>
@@ -242,9 +243,31 @@ ACPAssignTitlePatch(MCPTitleListType* titleInfo);
 ACPResult
 ACPGetTitleIdOfMainApplication(ACPTitleId* titleId);
 
+/**
+ * Gets the MetaXML for a given title id
+ * @param titleId
+ * @param metaXml must be aligned to 0x40
+ * @return ACP_RESULT_SUCCESS on success
+ */
 ACPResult
+RPLWRAP(ACPGetTitleMetaXml)(ACPTitleId titleId,
+                            ACPMetaXml *metaXml);
+
+/**
+ * Gets the MetaXML for a given title id
+ * @param titleId
+ * @param metaXml must be aligned to 0x40
+ * @return ACP_RESULT_SUCCESS on success,
+ *         ACP_RESULT_INVALID_PARAMETER if metaXml is not aligned properly
+ */
+static inline ACPResult
 ACPGetTitleMetaXml(ACPTitleId titleId,
-                   ACPMetaXml* metaXml);
+                   ACPMetaXml *metaXml) {
+   if ((uintptr_t) metaXml & 0x3F) {
+      return ACP_RESULT_INVALID_PARAMETER;
+   }
+   return RPLWRAP(ACPGetTitleMetaXml)(titleId, metaXml);
+}
 
 ACPResult
 ACPGetTitleMetaDirByDevice(ACPTitleId titleId,


### PR DESCRIPTION
Previously getting metaXML didn't work when the ACPMetaXml ptr was not aligned to 0x40, this implementation enforces the correct alignment.
