### PR TITLE
gx2: Add clip control functions

### DIFF
--- a/include/gx2/registers.h
+++ b/include/gx2/registers.h
@@ -615,6 +615,20 @@ GX2GetViewportReg(GX2ViewportReg *reg,
 void
 GX2SetViewportReg(const GX2ViewportReg *reg);
 
+void
+GX2SetRasterizerClipControl(BOOL rasterizer,
+                            BOOL zclipEnable);
+
+void
+GX2SetRasterizerClipControlEx(BOOL rasterizer,
+                              BOOL zclipEnable,
+                              BOOL halfZ);
+
+void
+GX2SetRasterizerClipControlHalfZ(BOOL rasterizer,
+                                 BOOL zclipEnable,
+                                 BOOL halfZ);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Copied from [decaf-emu](https://github.com/decaf-emu/decaf-emu/blob/75993f0a6d2b030485e2d01404786614a2b5fbea/src/libdecaf/src/cafe/libraries/gx2/gx2_registers.h#L594-L606) (renamed `rasteriser` to `rasterizer` to match function name).