### PR TITLE
Add wut_load_bounds section to prevent loader bug

### DIFF
--- a/share/wut.ld
+++ b/share/wut.ld
@@ -102,6 +102,8 @@ SECTIONS
    } > datamem
 
    . = ORIGIN(loadmem);
+   .wut_load_bounds : { LONG(0) } > loadmem
+
    .fexports ALIGN(32) : { KEEP( *(.fexports) ) } > loadmem
    .dexports ALIGN(32) : { KEEP( *(.dexports) ) } > loadmem
 


### PR DESCRIPTION
The CafeOS loader skips import sections when calculating the lower bounds of loader info (see [decaf-emu](https://github.com/decaf-emu/decaf-emu/blob/6feb1be1db3938e6da2d4a65fc0a7a8599fc8dd6/src/libdecaf/src/cafe/loader/cafe_loader_setup.cpp#L478)).
This ends up using symtab for the lower bound which comes after the imports, resulting in a negative offset [here](https://github.com/decaf-emu/decaf-emu/blob/6feb1be1db3938e6da2d4a65fc0a7a8599fc8dd6/src/libdecaf/src/cafe/loader/cafe_loader_setup.cpp#L318).

This PR adds a dummy section (which is not using the import type) before the imports in loadmem, which makes sure the lower bounds stay correct.