### PR TITLE
Replace the CafeOS default heap with a custom one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SOURCES		:=	cafe \
 				libraries/wutmalloc \
 				libraries/wutdevoptab \
 				libraries/wutsocket \
+				libraries/wutdefaultheap \
 				libraries/libwhb/src \
 				libraries/libgfd/src \
 				libraries/nn_erreula \

--- a/libraries/wutcrt/crt0_rpl.s
+++ b/libraries/wutcrt/crt0_rpl.s
@@ -17,6 +17,8 @@ __rpl_start:
 load:
    # Load
    bl __init_wut
+   # rpl files use wutmalloc instead of the custom heap
+   bl __init_wut_malloc
    bl __eabi
    lwz 3, 0xC(1)
    lwz 4, 0x10(1)

--- a/libraries/wutcrt/crt0_rpx.s
+++ b/libraries/wutcrt/crt0_rpx.s
@@ -32,4 +32,3 @@ __rpx_start:
 .long 0x10
 
 .string "__preinit_user"
-.byte 0

--- a/libraries/wutcrt/crt0_rpx.s
+++ b/libraries/wutcrt/crt0_rpx.s
@@ -2,6 +2,7 @@
 .extern exit
 .extern __init_wut
 .extern __fini_wut
+.extern __preinit_user
 
 .section .crt0, "ax", @progbits
 .global __rpx_start
@@ -17,3 +18,18 @@ __rpx_start:
    bl main
    addi 1, 1, 0x14
    b exit
+
+# -----------------------------------
+# export for __preinit_user
+# -----------------------------------
+.section .fexports, "ax", @0x80000001
+.align 4
+
+.long 1
+.long 0xa7fef0c2
+
+.long __preinit_user
+.long 0x10
+
+.string "__preinit_user"
+.byte 0

--- a/libraries/wutcrt/wut_crt.c
+++ b/libraries/wutcrt/wut_crt.c
@@ -1,10 +1,8 @@
-void __init_wut_malloc();
 void __init_wut_newlib();
 void __init_wut_stdcpp();
 void __init_wut_devoptab();
 void __attribute__((weak)) __init_wut_socket();
 
-void __fini_wut_malloc();
 void __fini_wut_newlib();
 void __fini_wut_stdcpp();
 void __fini_wut_devoptab();
@@ -13,7 +11,6 @@ void __attribute__((weak)) __fini_wut_socket();
 void __attribute__((weak))
 __init_wut()
 {
-   __init_wut_malloc();
    __init_wut_newlib();
    __init_wut_stdcpp();
    __init_wut_devoptab();
@@ -27,5 +24,4 @@ __fini_wut()
    __fini_wut_devoptab();
    __fini_wut_stdcpp();
    __fini_wut_newlib();
-   __fini_wut_malloc();
 }

--- a/libraries/wutcrt/wut_preinit.c
+++ b/libraries/wutcrt/wut_preinit.c
@@ -1,0 +1,15 @@
+#include <coreinit/memdefaultheap.h>
+
+void __init_wut_sbrk_heap(MEMHeapHandle heapHandle);
+void __init_wut_malloc_lock();
+void __init_wut_defaultheap();
+
+void __attribute__((weak))
+__preinit_user(MEMHeapHandle *mem1,
+               MEMHeapHandle *foreground,
+               MEMHeapHandle *mem2)
+{
+    __init_wut_sbrk_heap(*mem2);
+    __init_wut_malloc_lock();
+    __init_wut_defaultheap();
+}

--- a/libraries/wutdefaultheap/wut_defaultheap.c
+++ b/libraries/wutdefaultheap/wut_defaultheap.c
@@ -1,0 +1,34 @@
+#include <coreinit/memdefaultheap.h>
+#include <malloc.h>
+
+void *
+__wut_alloc_from_defaultheap(uint32_t size)
+{
+   return malloc(size);
+}
+
+void *
+__wut_alloc_from_defaultheap_ex(uint32_t size, 
+                              int32_t alignment)
+{
+   return memalign(alignment, size);
+}
+
+void 
+__wut_free_to_defaultheap(void *ptr)
+{
+   free(ptr);
+}
+
+void
+__init_wut_defaultheap(void)
+{
+   MEMAllocFromDefaultHeap = __wut_alloc_from_defaultheap;
+   MEMAllocFromDefaultHeapEx = __wut_alloc_from_defaultheap_ex;
+   MEMFreeToDefaultHeap = __wut_free_to_defaultheap;
+}
+
+void
+__fini_wut_defaultheap(void)
+{
+}

--- a/libraries/wutmalloc/wut_malloc.c
+++ b/libraries/wutmalloc/wut_malloc.c
@@ -5,9 +5,6 @@
 #include <string.h>
 #include <errno.h>
 
-// Limit sbrk heap to 128kb
-uint32_t __wut_heap_max_size = 128 * 1024;
-
 void
 __init_wut_malloc(void)
 {

--- a/libraries/wutnewlib/wut_malloc_lock.c
+++ b/libraries/wutnewlib/wut_malloc_lock.c
@@ -1,23 +1,23 @@
 #include "wut_newlib.h"
 
-#include <coreinit/mutex.h>
+#include <coreinit/spinlock.h>
 
-static OSMutex sMallocMutex;
+static OSSpinLock sMallocSpinLock;
 
 void
 __wut_malloc_lock(struct _reent *r)
 {
-   OSLockMutex(&sMallocMutex);
+   OSUninterruptibleSpinLock_Acquire(&sMallocSpinLock);
 }
 
 void
 __wut_malloc_unlock(struct _reent *r)
 {
-   OSUnlockMutex(&sMallocMutex);
+   OSUninterruptibleSpinLock_Release(&sMallocSpinLock);
 }
 
 void
 __init_wut_malloc_lock()
 {
-   OSInitMutex(&sMallocMutex);
+   OSInitSpinLock(&sMallocSpinLock);
 }

--- a/libraries/wutnewlib/wut_newlib.c
+++ b/libraries/wutnewlib/wut_newlib.c
@@ -4,6 +4,10 @@
 void(*__wut_exit)(int rc);
 extern void __fini_wut(void);
 
+void *__syscall_sbrk_r(struct _reent *ptr, ptrdiff_t incr) {
+	return __wut_sbrk_r(ptr, incr);
+}
+
 int __syscall_lock_init(int *lock, int recursive) {
   return __wut_lock_init(lock, recursive);
 }
@@ -18,6 +22,14 @@ int __syscall_lock_release(int *lock) {
 
 int __syscall_lock_acquire(int *lock) {
   return __wut_lock_acquire(lock);
+}
+
+void __syscall_malloc_lock(struct _reent *ptr) {
+	return __wut_malloc_lock(ptr);
+}
+
+void __syscall_malloc_unlock(struct _reent *ptr) {
+	return __wut_malloc_unlock(ptr);
 }
 
 void __syscall_exit(int rc) { 
@@ -54,4 +66,5 @@ __init_wut_newlib()
 void
 __fini_wut_newlib()
 {
+  __fini_wut_sbrk_heap();
 }


### PR DESCRIPTION
## Summary
Wut currently uses wutmalloc as a wrapper around the default CafeOS heap functions (`MEMAllocFromDefaultHeap` / `MEMFreeToDefaultHeap`).
This default heap is really slow for large amounts of allocations, which causes lots of slowdowns. A lot of retail games use a fast custom heap to prevent this issue.
This draft uses the malloc implementation in newlib instead and replaces the default heap functions with a wrapper around the newlib functions (see wutdefaultheap).
This is currently marked as a draft since it's a somewhat major change and there might be potential issues resulting from this which I haven't thought of.

## RPX files
RPX files now implement and export a `__preinit_user` function, which will be called before any allocations are done to allow replacing the `MEMAllocFromDefaultHeap` / `MEMFreeToDefaultHeap` functions (see [memdefaultheap.h](https://github.com/devkitPro/wut/blob/master/include/coreinit/memdefaultheap.h#L40)).

In the preinit call wut allocates all of the available space in the MEM2 heap for sbrk.
It then initializes wutdefaultheap which will replace  `MEMAllocFromDefaultHeap` / `MEMAllocFromDefaultHeapEx` / `MEMFreeToDefaultHeap` with wrappers around the newlib functions. This results in CafeOS functions allocating from the newlib heap instead.

### Overriding this behavior
The user can override this behavior by implementing their own `__preinit_user` function.
This will skip the sbrk and wutdefaultheap initialization, and `__init_wut_malloc` can be called which results in linking in the old wrapper around the default heap.
See [this code](https://github.com/GaryOderNichts/wut_heap_test/blob/main/main.c#L21) for an example.

## RPL files
Since RPL files don't support `__preinit_user` (and shouldn't mess with the default heap), they will simply use wutmalloc which results in allocations from the heap, which RPX has set up.

## Speed comparisons
For testing the speed I wrote [a simple tool](https://github.com/GaryOderNichts/wut_heap_test), which does a lot of heap allocations of various sizes, frees them, and displays the times they took.
This tool is probably not the best for accurate timing, but should be enough to show the performance increase.

### Using the default CafeOS heap:
|     | Allocations | Free |
| -- | ------ | ------ |
| malloc | 51321 µs | 25250 µs |
| memalign | 44195 µs | 29695 µs |

Total time: 150461 µs

### Using the custom newlib heap:
|     | Allocations | Free |
| -- | ------ | ------ |
| malloc | 6265 µs | 3410 µs |
| memalign | 15019 µs | 3676 µs |

Total time: 28370 µs

This is roughly a 5x total time improvement.

