### PR TITLE
wutdevoptab: Fix undefined behaviour for unimplemented function

### DIFF
--- a/libraries/wutdevoptab/devoptab_fs.c
+++ b/libraries/wutdevoptab/devoptab_fs.c
@@ -25,10 +25,12 @@ __wut_fs_devoptab =
    .statvfs_r    = __wut_fs_statvfs,
    .ftruncate_r  = __wut_fs_ftruncate,
    .fsync_r      = __wut_fs_fsync,
+   .lstat_r      = __wut_fs_stat,
    .deviceData   = NULL,
    .chmod_r      = __wut_fs_chmod,
    .fchmod_r     = __wut_fs_fchmod,
    .rmdir_r      = __wut_fs_rmdir,
+   .utimes_r     = __wut_fs_utimes,
 };
 
 FSClient *

--- a/libraries/wutdevoptab/devoptab_fs.h
+++ b/libraries/wutdevoptab/devoptab_fs.h
@@ -77,6 +77,7 @@ int       __wut_fs_fsync(struct _reent *r, void *fd);
 int       __wut_fs_chmod(struct _reent *r, const char *path, mode_t mode);
 int       __wut_fs_fchmod(struct _reent *r, void *fd, mode_t mode);
 int       __wut_fs_rmdir(struct _reent *r, const char *name);
+int       __wut_fs_utimes(struct _reent *r, const char *filename, const struct timeval times[2]);
 
 // devoptab_fs_utils.c
 char *    __wut_fs_fixpath(struct _reent *r, const char *path);

--- a/libraries/wutdevoptab/devoptab_fs_getmtime.c
+++ b/libraries/wutdevoptab/devoptab_fs_getmtime.c
@@ -1,9 +1,0 @@
-#include "devoptab_fs.h"
-
-int
-__wut_fs_getmtime(const char *name,
-                  uint64_t *mtime)
-{
-   // TODO: Last modified time can probably be get via FSGetStatFile
-   return -1;
-}

--- a/libraries/wutdevoptab/devoptab_fs_utimes.c
+++ b/libraries/wutdevoptab/devoptab_fs_utimes.c
@@ -1,0 +1,10 @@
+#include "devoptab_fs.h"
+
+int
+__wut_fs_utimes(struct _reent *r,
+        const char *filename,
+        const struct timeval times[2])
+{
+   r->_errno = ENOSYS;
+   return -1;
+}


### PR DESCRIPTION
Some functions return a undefined return code if they are not implemeted properly. See [here](https://github.com/devkitPro/newlib/blob/devkitPPC/libgloss/libsysbase/lstat.c#L14) and [here](https://github.com/devkitPro/newlib/blob/devkitPPC/libgloss/libsysbase/utime.c#L12)