### PR TITLE
wutcrt: Add a trapword in case a debugger is initialized to allow debugging

### DIFF
--- a/libraries/wutcrt/wut_crt.c
+++ b/libraries/wutcrt/wut_crt.c
@@ -1,3 +1,4 @@
+#include <coreinit/debug.h>
 void __init_wut_newlib();
 void __init_wut_stdcpp();
 void __init_wut_devoptab();
@@ -11,6 +12,9 @@ void __attribute__((weak)) __fini_wut_socket();
 void __attribute__((weak))
 __init_wut()
 {
+   if (OSIsDebuggerInitialized()) {
+      __asm__ __volatile__("tw 0x1f, 30, 0");
+   }
    __init_wut_newlib();
    __init_wut_stdcpp();
    __init_wut_devoptab();


### PR DESCRIPTION
A debugger like [Wii-U-Debugger](https://github.com/kinnay/Wii-U-Debugger) is triggered by a trapword. To allows debugging of homebrew .rpx this PR will add the `OSIsDebuggerInitialized`-check thats present in all retail titles to the CRT