### PR TITLE
wutdevoptab: Fix "syncing" the file->offset with the real offset on append mode.

### DIFF
--- a/libraries/wutdevoptab/devoptab_fs.h
+++ b/libraries/wutdevoptab/devoptab_fs.h
@@ -25,6 +25,9 @@ typedef struct
 
    //! Current file offset
    uint32_t offset;
+
+   //! Current file size (only valid if O_APPEND is set)
+   uint32_t appendOffset;
 } __wut_fs_file_t;
 
 

--- a/libraries/wutdevoptab/devoptab_fs_open.c
+++ b/libraries/wutdevoptab/devoptab_fs_open.c
@@ -59,14 +59,17 @@ __wut_fs_open(struct _reent *r,
    file = (__wut_fs_file_t *)fileStruct;
    file->fd = fd;
    file->flags = (flags & (O_ACCMODE|O_APPEND|O_SYNC));
+   // Is always 0, even if O_APPEND is set.
    file->offset = 0;
    if (flags & O_APPEND) {
-      status = FSGetPosFile(__wut_devoptab_fs_client, &cmd, fd, &file->offset, FS_ERROR_FLAG_ALL);
+      FSStat stat;
+      status = FSGetStatFile(__wut_devoptab_fs_client, &cmd, fd, &stat, FS_ERROR_FLAG_ALL);
       if (status < 0) {
          FSCloseFile(__wut_devoptab_fs_client, &cmd, fd, FS_ERROR_FLAG_ALL);
          r->_errno = __wut_fs_translate_error(status);
          return -1;
       }
+      file->appendOffset = stat.size;
    }
 
    return 0;

--- a/libraries/wutdevoptab/devoptab_fs_write.c
+++ b/libraries/wutdevoptab/devoptab_fs_write.c
@@ -19,6 +19,12 @@ ssize_t __wut_fs_write(struct _reent *r, void *fd, const char *ptr, size_t len) 
    FSCmdBlock cmd;
    FSInitCmdBlock(&cmd);
 
+   // If O_APPEND is set, we always write to the end of the file.
+   // When writing we file->offset to the file size to keep in sync.
+   if(file->flags & O_APPEND) {
+      file->offset = file->appendOffset;
+   }
+
    size_t bytesWritten = 0;
    while (bytesWritten < len) {
       // only use input buffer if cache-aligned and write size is a multiple of cache line size
@@ -53,6 +59,7 @@ ssize_t __wut_fs_write(struct _reent *r, void *fd, const char *ptr, size_t len) 
          return -1;
       }
 
+      file->appendOffset += status;
       file->offset += status;
       bytesWritten += status;
       ptr += status;


### PR DESCRIPTION
In order to keep our "file offset" and real file offset in sync, we need to update the file->offset to the current filesize on each write if O_APPEND is set. 