### PR TITLE
Fix and improve usage of atomics

### DIFF
--- a/libraries/wutnewlib/wut_lock.c
+++ b/libraries/wutnewlib/wut_lock.c
@@ -6,7 +6,7 @@
 #define MAX_LOCKS 16
 
 static OSMutex sLibcLocks[MAX_LOCKS];
-static uint32_t sLibcLockUsedMask = 0;
+static volatile uint32_t sLibcLockUsedMask = 0;
 
 static inline bool
 __wut_is_lock_valid(int *lock)

--- a/libraries/wutnewlib/wut_sbrk.c
+++ b/libraries/wutnewlib/wut_sbrk.c
@@ -14,17 +14,17 @@ void *
 __wut_sbrk_r(struct _reent *r,
              ptrdiff_t incr)
 {
-   uint32_t oldSize, newSize;
+   uint32_t newSize;
+   uint32_t oldSize = sHeapSize;
 
    do {
-      oldSize = sHeapSize;
       newSize = oldSize + incr;
 
       if (newSize > sHeapMaxSize) {
          r->_errno = ENOMEM;
          return (void *)-1;
       }
-   } while (!OSCompareAndSwapAtomic(&sHeapSize, oldSize, newSize));
+   } while (!OSCompareAndSwapAtomicEx(&sHeapSize, oldSize, newSize, &oldSize));
 
    return ((uint8_t *)sHeapBase) + oldSize;
 }

--- a/libraries/wutstdc++/wut_gthread_once.cpp
+++ b/libraries/wutstdc++/wut_gthread_once.cpp
@@ -11,9 +11,8 @@ __wut_once(__wut_once_t *once,
                                 __WUT_ONCE_VALUE_STARTED,
                                 &value)) {
       func();
-      OSCompareAndSwapAtomic(once,
-                             __WUT_ONCE_VALUE_STARTED,
-                             __WUT_ONCE_VALUE_DONE);
+      OSSwapAtomic(once,
+                   __WUT_ONCE_VALUE_DONE);
    } else if (value != __WUT_ONCE_VALUE_DONE) {
       while (!OSCompareAndSwapAtomic(once,
                                      __WUT_ONCE_VALUE_DONE,


### PR DESCRIPTION
- Replaces the usage of the built-in atomics with the OS* atomics from coreinit.
  This avoids a hardware bug described [here](https://fail0verflow.com/blog/2014/console-hacking-2013-omake/).
  > There appears to be a bug that affects load-exclusive and store-exclusive instructions (an explicit cache flush is required)

  The gcc built-in atomics do not emit a cache flush which might cause issues in the current wut lock implementation.
- Uses `OSSwapAtomic` in wutstdc++'s once implementation where a compare isn't necessary.
- Uses `OSCompareAndSwapAtomicEx` to directly update the oldSize in the newlib `sbrk` implementation.