### PR TITLE
Add several definitions for Multi/Double DRC mode

### DIFF
--- a/include/avm/drc.h
+++ b/include/avm/drc.h
@@ -19,8 +19,21 @@ typedef enum AVMDrcScanMode
    AVM_DRC_SCAN_MODE_UNKNOWN_255 = 255,
 } AVMDrcScanMode;
 
+typedef enum AVMDrcMode
+{
+   AVM_DRC_MODE_NONE = 0,
+   AVM_DRC_MODE_SINGLE = 1,
+   AVM_DRC_MODE_DOUBLE = 2,
+} AVMDrcMode;
+
 BOOL
 AVMGetDRCScanMode(AVMDrcScanMode *outScanMode);
+
+BOOL
+AVMGetDRCMode(AVMDrcMode *outMode);
+
+uint32_t
+AVMProbeDRCNum(void);
 
 #ifdef __cplusplus
 }

--- a/include/gx2/display.h
+++ b/include/gx2/display.h
@@ -13,6 +13,8 @@
 extern "C" {
 #endif
 
+typedef void (*GX2DRCConnectCallback)(uint32_t drcSlot, BOOL attached);
+
 void
 GX2SetTVEnable(BOOL enable);
 
@@ -63,6 +65,10 @@ GX2GetSystemDRCScanMode();
 
 GX2DrcRenderMode
 GX2GetSystemDRCMode();
+
+GX2DRCConnectCallback
+GX2SetDRCConnectCallback(uint32_t drcSlot,
+                         GX2DRCConnectCallback callback);
 
 #ifdef __cplusplus
 }

--- a/include/gx2/enum.h
+++ b/include/gx2/enum.h
@@ -180,6 +180,7 @@ typedef enum GX2DrcRenderMode
 {
    GX2_DRC_RENDER_MODE_DISABLED           = 0,
    GX2_DRC_RENDER_MODE_SINGLE             = 1,
+   GX2_DRC_RENDER_MODE_DOUBLE             = 2,
 } GX2DrcRenderMode;
 
 typedef enum GX2EventType
@@ -325,8 +326,12 @@ typedef enum GX2SamplerVarType
 
 typedef enum GX2ScanTarget
 {
-   GX2_SCAN_TARGET_TV                     = 1,
-   GX2_SCAN_TARGET_DRC                    = 4,
+   GX2_SCAN_TARGET_TV0                    = 1 << 0,
+   GX2_SCAN_TARGET_TV1                    = 1 << 1,
+   GX2_SCAN_TARGET_DRC0                   = 1 << 2,
+   GX2_SCAN_TARGET_DRC1                   = 1 << 3,
+   GX2_SCAN_TARGET_TV                     = GX2_SCAN_TARGET_TV0,
+   GX2_SCAN_TARGET_DRC                    = GX2_SCAN_TARGET_DRC0,
 } GX2ScanTarget;
 
 typedef enum GX2ShaderMode

--- a/include/vpad/input.h
+++ b/include/vpad/input.h
@@ -84,6 +84,8 @@ typedef enum VPADChan
 {
    //! Channel 0.
    VPAD_CHAN_0                   = 0,
+   //! Channel 1.
+   VPAD_CHAN_1                   = 1,
 } VPADChan;
 
 //! Touch pad validity.

--- a/libraries/libwhb/src/gfx.c
+++ b/libraries/libwhb/src/gfx.c
@@ -307,7 +307,7 @@ WHBGfxInit()
    };
    GX2Init(initAttribs);
 
-   sDrcRenderMode = GX2GetSystemDRCScanMode();
+   sDrcRenderMode = GX2GetSystemDRCMode();
    sTvSurfaceFormat = GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8;
    sDrcSurfaceFormat = GX2_SURFACE_FORMAT_UNORM_R8_G8_B8_A8;
 


### PR DESCRIPTION
Allows making use of the MultiDRC mode, which can be enabled with the functions from #264 and #265.
Not sure what `GX2_SCAN_TARGET_TV1` is used for, from RE'ing GX2 it seems to copy the colorbuffer to some TV scanbuffer.
`GX2GetSystemDRCScanMode` was replaced with `GX2GetSystemDRCMode` in WhbGfx since `GX2GetSystemDRCScanMode` doesn't seem to keep the second GamePad in mind.