### PR TITLE
nn::Result: add missing modules

### DIFF
--- a/include/nn/result.h
+++ b/include/nn/result.h
@@ -108,6 +108,13 @@ public:
       RESULT_MODULE_NN_VCTL               = 18,
       RESULT_MODULE_NN_NEIA               = 19,
       RESULT_MODULE_NN_SPM                = 20,
+      RESULT_MODULE_NN_EMD                = 21,
+      RESULT_MODULE_NN_EC                 = 22,
+      RESULT_MODULE_NN_CIA                = 23,
+      RESULT_MODULE_NN_SL                 = 24,
+      RESULT_MODULE_NN_ECO                = 25,
+      RESULT_MODULE_NN_TRIAL              = 26,
+      RESULT_MODULE_NN_NFP                = 27,
       RESULT_MODULE_NN_TEST               = 125,
    };
 


### PR DESCRIPTION
From [decaf-emu](https://github.com/decaf-emu/decaf-emu/blob/master/src/libdecaf/src/nn/nn_result.h#L41-L47).