### PR TITLE
wutstdc++: Check if memory allocations were successful on thread creation

### DIFF
--- a/libraries/wutstdc++/wut_gthread_thread.cpp
+++ b/libraries/wutstdc++/wut_gthread_thread.cpp
@@ -24,8 +24,15 @@ __wut_thread_create(OSThread **outThread,
                     void *entryArgs)
 {
    OSThread *thread = (OSThread *)memalign(16, sizeof(OSThread));
-   char *stack = (char *)memalign(16, __WUT_STACK_SIZE);
+   if (!thread) {
+      return ENOMEM;
+   }   
    memset(thread, 0, sizeof(OSThread));
+
+   char *stack = (char *)memalign(16, __WUT_STACK_SIZE);
+   if (!stack) {
+      return ENOMEM;
+   }
 
    if (!OSCreateThread(thread,
                        (OSThreadEntryPointFn)entryPoint,


### PR DESCRIPTION
We should return an error when allocating memory. This allows us to catch a exception instead of crashing.