### PR TITLE
wutstdc++: Decrease the stack size for gthread threads from 4 MiB to 128 KiB

### DIFF
--- a/libraries/wutstdc++/wut_gthread.h
+++ b/libraries/wutstdc++/wut_gthread.h
@@ -7,7 +7,7 @@
 #include <coreinit/mutex.h>
 
 #define __WUT_MAX_KEYS (128)
-#define __WUT_STACK_SIZE (4096*1024)
+#define __WUT_STACK_SIZE (128*1024)
 
 #define __WUT_ONCE_VALUE_INIT (0)
 #define __WUT_ONCE_VALUE_STARTED (1)

--- a/libraries/wutstdc++/wut_gthread_thread.cpp
+++ b/libraries/wutstdc++/wut_gthread_thread.cpp
@@ -1,8 +1,10 @@
 #include "wut_gthread.h"
 
+#include <stdint.h>
 #include <malloc.h>
 #include <string.h>
 #include <sys/errno.h>
+uint32_t __attribute__((weak)) __wut_thread_default_stack_size = __WUT_STACK_SIZE;
 
 static void
 __wut_thread_deallocator(OSThread *thread,
@@ -27,9 +29,10 @@ __wut_thread_create(OSThread **outThread,
    if (!thread) {
       return ENOMEM;
    }   
+
    memset(thread, 0, sizeof(OSThread));
 
-   char *stack = (char *)memalign(16, __WUT_STACK_SIZE);
+   char *stack = (char *)memalign(16, __wut_thread_default_stack_size);
    if (!stack) {
       free(thread);
       return ENOMEM;
@@ -39,8 +42,8 @@ __wut_thread_create(OSThread **outThread,
                        (OSThreadEntryPointFn)entryPoint,
                        (int)entryArgs,
                        NULL,
-                       stack + __WUT_STACK_SIZE,
-                       __WUT_STACK_SIZE,
+                       stack + __wut_thread_default_stack_size,
+                       __wut_thread_default_stack_size,
                        16,
                        OS_THREAD_ATTRIB_AFFINITY_ANY)) {
       free(thread);


### PR DESCRIPTION
At the moment the default stack size for threads is 4MiB, which seems to be way to much. Especially if you use threads in aroma modules/plugins where memory will be very limited (only ~60MiB for all plugins/modules code, data and heap).

For reference: The stack size for the default Cafe OS thread is 64Kib.

The actual value for the new stack size is open for discussion