### PR TITLE
wutdevoptab: check size of a read/write before checking the buffer alignment to reduce the read/write calls

### DIFF
--- a/libraries/wutdevoptab/devoptab_fs_read.c
+++ b/libraries/wutdevoptab/devoptab_fs_read.c
@@ -28,13 +28,13 @@ ssize_t __wut_fs_read(struct _reent *r, void *fd, char *ptr, size_t len) {
       uint8_t *tmp = (uint8_t *) ptr;
       size_t size = len - bytesRead;
 
-      if ((uintptr_t) ptr & 0x3F) {
+      if (size < 0x40) {
+         // read partial cache-line back-end
+         tmp = alignedBuffer;
+      } else if ((uintptr_t) ptr & 0x3F) {
          // read partial cache-line front-end
          tmp = alignedBuffer;
          size = MIN(size, 0x40 - ((uintptr_t) ptr & 0x3F));
-      } else if (size < 0x40) {
-         // read partial cache-line back-end
-         tmp = alignedBuffer;
       } else {
          // read whole cache lines
          size &= ~0x3F;

--- a/libraries/wutdevoptab/devoptab_fs_write.c
+++ b/libraries/wutdevoptab/devoptab_fs_write.c
@@ -32,13 +32,13 @@ ssize_t __wut_fs_write(struct _reent *r, void *fd, const char *ptr, size_t len) 
       uint8_t *tmp = (uint8_t *) ptr;
       size_t size = len - bytesWritten;
 
-      if ((uintptr_t) ptr & 0x3F) {
+      if (size < 0x40) {
+         // write partial cache-line back-end
+         tmp = alignedBuffer;
+      } else if ((uintptr_t) ptr & 0x3F) {
          // write partial cache-line front-end
          tmp = alignedBuffer;
          size = MIN(size, 0x40 - ((uintptr_t) ptr & 0x3F));
-      } else if (size < 0x40) {
-         // write partial cache-line back-end
-         tmp = alignedBuffer;
       } else {
          // write whole cache lines
          size &= ~0x3F;


### PR DESCRIPTION
If the size is < 0x40 we need to use the aligned buffer anyway, so we check this first to avoid splitting the call up into multiple calls.

Example:
With the **previous** implementation writing 26 bytes from buffer 0x10000038, will result two write calls.
First call writes 8 bytes (buffer not aligned => `MIN(size, 0x40 - ((uintptr_t) ptr & 0x3F)`), the other one the remaining 18 bytes (buffer is now aligned, but size is now < 0x40).

With the **new** implementation the same operation (write 26 bytes from 0x10000038) would just result in one single 26 bytes (because `size < 0x40` is checked first) call.