### PR TITLE
libwhb: Fix length check in ConsoleAddLine

### DIFF
--- a/libraries/libwhb/src/console.c
+++ b/libraries/libwhb/src/console.c
@@ -26,7 +26,7 @@ ConsoleAddLine(const char *line)
 {
    int length = strlen(line);
 
-   if (length > LINE_LENGTH) {
+   if (length >= LINE_LENGTH) {
       length = LINE_LENGTH - 1;
    }
 


### PR DESCRIPTION
Previously input strings with the length == LINE_LENGTH considered "okay", but lead to a to out of bounce write (`sConsoleBuffer[sLineNum][length] = 0;`)