### PR TITLE
A little fleshing out of the dynamic library header

### DIFF
--- a/include/coreinit/dynload.h
+++ b/include/coreinit/dynload.h
@@ -29,10 +29,16 @@ typedef enum OSDynLoad_Error
    OS_DYNLOAD_INVALID_ALLOCATOR_PTR       = 0xBAD10017,
    OS_DYNLOAD_OUT_OF_SYSTEM_MEMORY        = 0xBAD1002F,
    OS_DYNLOAD_TLS_ALLOCATOR_LOCKED        = 0xBAD10031,
+   OS_DYNLOAD_MODULE_NOT_FOUND            = -6,
 } OSDynLoad_Error;
 
 typedef OSDynLoad_Error (*OSDynLoadAllocFn)(int32_t size, int32_t align, void **outAddr);
 typedef void (*OSDynLoadFreeFn)(void *addr);
+
+typedef enum OSDynLoad_ExportType {
+  OS_DYNLOAD_EXPORT_FUNC = 0,
+  OS_DYNLOAD_EXPORT_DATA = 1,
+} OSDynLoad_ExportType;
 
 typedef enum OSDynLoad_EntryReason
 {
@@ -114,7 +120,7 @@ OSDynLoad_Acquire(char const *name,
  */
 OSDynLoad_Error
 OSDynLoad_FindExport(OSDynLoad_Module module,
-                     BOOL isData,
+                     OSDynLoad_ExportType exportType,
                      char const *name,
                      void **outAddr);
 


### PR DESCRIPTION
== DETAILS

This commit provides two tweaks:

1. Add the "library not found" error, value of -6, to the `OSDynLoad_Error` enums
2. Define an `OSDynLoad_ExportType` enum and use it in place of the `isData` boolean parameter to avoid raw `true`/`false` values in the code and make usages easier to read:

   ```c
   // before - unclear what "false" means in this context
   last_error = OSDynLoad_FindExport((OSDynLoad_Module)lib, false, proc, &ptr_sym);
   ```
   vs:
   ```c 
   // after - aha, we're looking up a function symbol 
   last_error = OSDynLoad_FindExport((OSDynLoad_Module)lib, OS_DYNLOAD_EXPORT_FUNC, proc, &ptr_sym);
   ```