### PR TITLE
coreinit: Add missing fields and enum definitions to OSThread and OSContext

### DIFF
--- a/include/coreinit/context.h
+++ b/include/coreinit/context.h
@@ -12,6 +12,14 @@
 extern "C" {
 #endif
 
+//! A bitfield of enum OS_CONTEXT_STATE.
+typedef uint16_t OSContextState;
+
+enum OS_CONTEXT_STATE {
+    OS_CONTEXT_STATE_OSCALLBACK     = 1 << 3,
+    OS_CONTEXT_STATE_USERMODE_SAVED = 1 << 4
+};
+
 typedef struct OSContext OSContext;
 
 #define OS_CONTEXT_TAG 0x4F53436F6E747874ull
@@ -34,9 +42,10 @@ struct WUT_ALIGNAS(8) OSContext
    uint32_t fpscr;
    double fpr[32];
    uint16_t spinLockCount;
-   uint16_t state;
+   OSContextState state;
    uint32_t gqr[8];
-   WUT_UNKNOWN_BYTES(4);
+   //! Current core index
+   uint32_t upir;
    double psf[32];
    uint64_t coretime[3];
    uint64_t starttime;
@@ -64,6 +73,7 @@ WUT_CHECK_OFFSET(OSContext, 0xb8, fpr);
 WUT_CHECK_OFFSET(OSContext, 0x1b8, spinLockCount);
 WUT_CHECK_OFFSET(OSContext, 0x1ba, state);
 WUT_CHECK_OFFSET(OSContext, 0x1bc, gqr);
+WUT_CHECK_OFFSET(OSContext, 0x1dc, upir);
 WUT_CHECK_OFFSET(OSContext, 0x1e0, psf);
 WUT_CHECK_OFFSET(OSContext, 0x2e0, coretime);
 WUT_CHECK_OFFSET(OSContext, 0x2f8, starttime);

--- a/include/coreinit/thread.h
+++ b/include/coreinit/thread.h
@@ -549,6 +549,8 @@ OSSleepTicks(OSTime ticks);
 uint32_t
 OSSuspendThread(OSThread *thread);
 
+void
+__OSSuspendThreadNolock(OSThread *thread);
 
 /**
  * Check to see if the current thread should be cancelled or suspended.

--- a/include/coreinit/thread.h
+++ b/include/coreinit/thread.h
@@ -45,6 +45,9 @@ typedef uint32_t OSThreadRequest;
 //! A bitfield of enum OS_THREAD_ATTRIB.
 typedef uint8_t OSThreadAttributes;
 
+//! A bitfield of enum OS_THREAD_TYPE.
+typedef uint32_t OSThreadType;
+
 typedef int (*OSThreadEntryPointFn)(int argc, const char **argv);
 typedef void (*OSThreadCleanupCallbackFn)(OSThread *thread, void *stack);
 typedef void (*OSThreadDeallocatorFn)(OSThread *thread, void *stack);
@@ -91,7 +94,15 @@ enum OS_THREAD_ATTRIB
    OS_THREAD_ATTRIB_DETACHED        = 1 << 3,
 
    //! Enables tracking of stack usage.
-   OS_THREAD_ATTRIB_STACK_USAGE     = 1 << 5
+   OS_THREAD_ATTRIB_STACK_USAGE     = 1 << 5,
+
+   OS_THREAD_ATTRIB_UNKNOWN         = 1 << 7
+};
+
+enum OS_THREAD_TYPE {
+    OS_THREAD_TYPE_DRIVER = 0,
+    OS_THREAD_TYPE_IO     = 1,
+    OS_THREAD_TYPE_APP    = 2
 };
 
 struct OSMutexQueue
@@ -179,7 +190,7 @@ struct WUT_ALIGNAS(8) OSThread
    //! Thread specific values, accessed with OSSetThreadSpecific and OSGetThreadSpecific.
    void *specific[0x10];
 
-   WUT_UNKNOWN_BYTES(0x5c0 - 0x5bc);
+   OSThreadType type;
 
    //! Thread name, accessed with OSSetThreadName and OSGetThreadName.
    const char *name;
@@ -231,6 +242,7 @@ WUT_CHECK_OFFSET(OSThread, 0x394, stackStart);
 WUT_CHECK_OFFSET(OSThread, 0x398, stackEnd);
 WUT_CHECK_OFFSET(OSThread, 0x39c, entryPoint);
 WUT_CHECK_OFFSET(OSThread, 0x57c, specific);
+WUT_CHECK_OFFSET(OSThread, 0x5bc, type);
 WUT_CHECK_OFFSET(OSThread, 0x5c0, name);
 WUT_CHECK_OFFSET(OSThread, 0x5c8, userStackPointer);
 WUT_CHECK_OFFSET(OSThread, 0x5cc, cleanupCallback);


### PR DESCRIPTION
See Cemu for reference:
<https://github.com/cemu-project/Cemu/blob/f3ff919be25189dcf4a0120b48360bb415d7b86c/src/Cafe/OS/libs/coreinit/coreinit_Thread.h#L37>
<https://github.com/cemu-project/Cemu/blob/f3ff919be25189dcf4a0120b48360bb415d7b86c/src/Cafe/OS/libs/coreinit/coreinit_Thread.h#L364-L369>
<https://github.com/cemu-project/Cemu/blob/f3ff919be25189dcf4a0120b48360bb415d7b86c/src/Cafe/OS/libs/coreinit/coreinit_Thread.h#L439>