### PR TITLE
coreinit: add OSGetCodegenVirtAddrRange

### DIFF
--- a/include/coreinit/codegen.h
+++ b/include/coreinit/codegen.h
@@ -121,6 +121,9 @@ OSGetSecCodeGenMode();
 BOOL
 OSCodegenCopy(void* dst, void* src, size_t size);
 
+void
+OSGetCodegenVirtAddrRange(void** outAddr, uint32_t* size);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
See decaf:
https://github.com/decaf-emu/decaf-emu/blob/6feb1be1db3938e6da2d4a65fc0a7a8599fc8dd6/src/libdecaf/src/cafe/libraries/coreinit/coreinit_codegen.h#L8