### PR TITLE
coreinit: Fix OSDynLoad_EntryReason values

### DIFF
--- a/include/coreinit/dynload.h
+++ b/include/coreinit/dynload.h
@@ -46,8 +46,8 @@ typedef enum OSDynLoad_ExportType {
 
 typedef enum OSDynLoad_EntryReason
 {
-  OS_DYNLOAD_LOADED                       = 0,
-  OS_DYNLOAD_UNLOADED                     = 1,
+  OS_DYNLOAD_LOADED                       = 1,
+  OS_DYNLOAD_UNLOADED                     = 2,
 } OSDynLoad_EntryReason;
 
 struct OSDynLoad_NotifyData


### PR DESCRIPTION
Should be LOAD=1 and UNLOAD=2. Checked with coreinit.rpl
Decaf also has it defined as 1 and 2 in the [EntryReason](https://github.com/decaf-emu/decaf-emu/blob/e8c9af3057a7d94f6e970406eb1ba1c37c87b4d1/src/libdecaf/src/cafe/libraries/coreinit/coreinit_enum.h#L95-L98) enum