### PR TITLE
Separate vpadbase from vpad

### DIFF
--- a/include/vpad/input.h
+++ b/include/vpad/input.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <wut.h>
+#include <vpadbase/base.h>
 
 /**
  * \defgroup vpad_input VPAD Input
@@ -78,15 +79,6 @@ typedef enum VPADButtons
    //! The emulated down button on the left stick.
    VPAD_STICK_L_EMULATION_DOWN   = 0x08000000,
 } VPADButtons;
-
-//! Wii U GamePad channel.
-typedef enum VPADChan
-{
-   //! Channel 0.
-   VPAD_CHAN_0                   = 0,
-   //! Channel 1.
-   VPAD_CHAN_1                   = 1,
-} VPADChan;
 
 //! Touch pad validity.
 typedef enum VPADTouchPadValidity
@@ -323,13 +315,6 @@ WUT_CHECK_OFFSET(VPADStatus, 0xA2, micStatus);
 WUT_CHECK_OFFSET(VPADStatus, 0xA3, slideVolumeEx);
 WUT_CHECK_SIZE(VPADStatus, 0xAC);
 
-typedef enum {
-   //! Indicates that there is pending data which can be received
-   VPAD_IRC_STATUS_FLAG_HAS_DATA    = 1,
-   //! Indicates that another device is connected
-   VPAD_IRC_STATUS_FLAG_CONNECTED   = 2,
-} VPADIRCStatusFlags;
-
 typedef void(*VPADSamplingCallback)(VPADChan chan);
 
 /**
@@ -480,40 +465,6 @@ VPADGetTPCalibratedPointEx(VPADChan chan,
                            VPADTouchPadResolution tpResolution,
                            VPADTouchData *calibratedData,
                            const VPADTouchData *uncalibratedData);
-
-/**
- * Return a count representing the amount of time left for the given Gamepad's
- * rumble pattern.
- *
- * \note
- * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
- * VPAD_CHAN_0. \endlink
- *
- * \param chan
- * Denotes which channel to get the rumble time from.
- */
-int32_t
-VPADBASEGetMotorOnRemainingCount(VPADChan chan);
-
-/**
- * Set a count representing the amount of time left for the given Gamepad's
- * rumble pattern.
- *
- * \note
- * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
- * VPAD_CHAN_0. \endlink
- *
- * \param chan
- * Denotes which channel to set the rumble count for.
- *
- * \param counter
- * The value of the new rumble count.
- *
- * <!-- meta: I assume this affects the index into the rumble pattern? -->
- */
-int32_t
-VPADBASESetMotorOnRemainingCount(VPADChan chan,
-                                 int32_t counter);
 
 void
 VPADSetAccParam(VPADChan chan,
@@ -860,120 +811,6 @@ int32_t
 VPADGetLcdMode(VPADChan chan,
                VPADLcdMode *outLcdMode);
 
-void
-VPADBASESetSensorBarSetting(VPADChan chan,
-                            int8_t setting);
-
-void
-VPADBASEGetSensorBarSetting(VPADChan chan,
-                            int8_t *outSetting);
-
-/**
- * Get the headphone status.
- *
- * \note
- * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
- * VPAD_CHAN_0. \endlink
- *
- * \param chan
- * The channel of the Gamepad to get the headphone status from.
- *
- * \returns
- * Returns 1 if headphones are connected, 0 otherwise.
- */
-int32_t
-VPADBASEGetHeadphoneStatus(VPADChan chan);
-
-/**
- * Get the controller mode.
- *
- * \note
- * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
- * VPAD_CHAN_0. \endlink
- *
- * \param chan
- * The channel of the Gamepad to get the controller mode from.
- *
- * \param mode
- * Pointer to write a value of the controller mode into.
- */
-void
-VPADBASEGetGameControllerMode(VPADChan chan,
-                              int32_t* mode);
-
-/**
- * Set the controller mode.
- *
- * \note
- * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
- * VPAD_CHAN_0. \endlink
- *
- * \param chan
- * The channel of the Gamepad to set the controller mode to.
- *
- * \param mode
- * Any non-zero mode will turn off the display, like the "Display Off" button under Controller Settings.
- * Inputs are not disabled.
- */
-void
-VPADBASESetGameControllerMode(VPADChan chan,
-                              int32_t mode);
-
-/**
- * Get the POWER button press status.
- *
- * \note
- * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
- * VPAD_CHAN_0. \endlink
- *
- * \param chan
- * The channel of the Gamepad to get the POWER button press status from.
- *
- * \param tick
- * The value given by \link OSGetTick \endlink when the button was pressed.
- *
- * \param status
- * The status is set to 0 if the POWER button is not pressed.
- */
-void
-VPADBASEGetPowerButtonPressStatus(VPADChan chan,
-                                  uint32_t* tick,
-                                  uint32_t *status);
-
-/**
- * Set the POWER button press status.
- *
- * \param chan
- * The channel of the Gamepad to set the POWER button press status to.
- *
- * \param tick
- * The tick value to set.
- *
- * \param status
- * The status to set.
- */
-void
-VPADBASESetPowerButtonPressStatus(VPADChan chan,
-                                  uint32_t tick,
-                                  uint32_t status);
-
-/**
- * Set the POWER button mode.
- *
- * \param chan
- * The channel of the Gamepad to set the POWER button disable mode to.
- *
- * \param mode
- * Set to 0 to enable and set to 1 to disable.
- *
- * \sa
- * - \link VPADDisablePowerButton \endlink
- * - \link VPADEnablePowerButton \endlink
- */
-void
-VPADBASESetPowerButtonDisableMode(VPADChan chan,
-                                  uint32_t mode);
-
 /**
  * Turn the given Gamepad's sensor bar on or off. Enabling the sensor bar allows
  * any Wii Remote to position itself relative to the GamePad.
@@ -999,35 +836,7 @@ VPADSamplingCallback
 VPADSetSamplingCallback(VPADChan chan,
                         VPADSamplingCallback callback);
 
-/**
- * Checks if VPADBASE is initialized.
- *
- * \returns
- * \c TRUE if initialized.
- */
-BOOL
-VPADBASEIsInit();
 
-/**
- * Clear pending IRC events.
- *
- * \param chan
- * The channel of the Gamepad.
- */
-void
-VPADBASEClearIRCEvent(VPADChan chan);
-
-/**
- * Get the current IRC status.
- *
- * \param chan
- * The channel of the Gamepad.
- * 
- * \returns
- * The current status flags (see \link VPADIRCStatusFlags \endlink).
- */
-uint32_t
-VPADBASEGetIRCStatus(VPADChan chan);
 
 #ifdef __cplusplus
 }

--- a/include/vpadbase/base.h
+++ b/include/vpadbase/base.h
@@ -1,0 +1,237 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup vpadbase_base VPAD Base
+ * \ingroup vpadbase
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//! Wii U GamePad channel.
+typedef enum VPADChan
+{
+   //! Channel 0.
+   VPAD_CHAN_0                   = 0,
+   //! Channel 1.
+   VPAD_CHAN_1                   = 1,
+} VPADChan;
+
+typedef enum
+{
+   //! Indicates that there is pending data which can be received
+   VPAD_IRC_STATUS_FLAG_HAS_DATA    = 1,
+   //! Indicates that another device is connected
+   VPAD_IRC_STATUS_FLAG_CONNECTED   = 2,
+} VPADIRCStatusFlags;
+
+/**
+ * Initializes the VPADBASE library for use.
+ *
+ * \note
+ * This is internally called by vpad and does not need to be called manually.
+ *
+ * \sa
+ * - \link VPADBASEShutdown \endlink
+ */
+void
+VPADBASEInit();
+
+/**
+ * Deinitializes the VPADBASE library.
+ *
+ * \note
+ * This is internally called by vpad and does not need to be called manually.
+ *
+ * \sa
+ * - \link VPADBASEInit \endlink
+ */
+void
+VPADBASEShutdown();
+
+/**
+ * Checks if VPADBASE is initialized.
+ *
+ * \returns
+ * \c TRUE if initialized.
+ */
+BOOL
+VPADBASEIsInit();
+
+/**
+ * Return a count representing the amount of time left for the given Gamepad's
+ * rumble pattern.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * Denotes which channel to get the rumble time from.
+ */
+int32_t
+VPADBASEGetMotorOnRemainingCount(VPADChan chan);
+
+/**
+ * Set a count representing the amount of time left for the given Gamepad's
+ * rumble pattern.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * Denotes which channel to set the rumble count for.
+ *
+ * \param counter
+ * The value of the new rumble count.
+ *
+ * <!-- meta: I assume this affects the index into the rumble pattern? -->
+ */
+int32_t
+VPADBASESetMotorOnRemainingCount(VPADChan chan,
+                                 int32_t counter);
+
+void
+VPADBASESetSensorBarSetting(VPADChan chan,
+                            int8_t setting);
+
+void
+VPADBASEGetSensorBarSetting(VPADChan chan,
+                            int8_t *outSetting);
+
+/**
+ * Get the headphone status.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * The channel of the Gamepad to get the headphone status from.
+ *
+ * \returns
+ * Returns 1 if headphones are connected, 0 otherwise.
+ */
+int32_t
+VPADBASEGetHeadphoneStatus(VPADChan chan);
+
+/**
+ * Get the controller mode.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * The channel of the Gamepad to get the controller mode from.
+ *
+ * \param mode
+ * Pointer to write a value of the controller mode into.
+ */
+void
+VPADBASEGetGameControllerMode(VPADChan chan,
+                              int32_t *mode);
+
+/**
+ * Set the controller mode.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * The channel of the Gamepad to set the controller mode to.
+ *
+ * \param mode
+ * Any non-zero mode will turn off the display, like the "Display Off" button under Controller Settings.
+ * Inputs are not disabled.
+ */
+void
+VPADBASESetGameControllerMode(VPADChan chan,
+                              int32_t mode);
+
+/**
+ * Get the POWER button press status.
+ *
+ * \note
+ * Retail Wii U systems have a single Gamepad on \link VPADChan::VPAD_CHAN_0
+ * VPAD_CHAN_0. \endlink
+ *
+ * \param chan
+ * The channel of the Gamepad to get the POWER button press status from.
+ *
+ * \param tick
+ * The value given by \link OSGetTick \endlink when the button was pressed.
+ *
+ * \param status
+ * The status is set to 0 if the POWER button is not pressed.
+ */
+void
+VPADBASEGetPowerButtonPressStatus(VPADChan chan,
+                                  uint32_t *tick,
+                                  uint32_t *status);
+
+/**
+ * Set the POWER button press status.
+ *
+ * \param chan
+ * The channel of the Gamepad to set the POWER button press status to.
+ *
+ * \param tick
+ * The tick value to set.
+ *
+ * \param status
+ * The status to set.
+ */
+void
+VPADBASESetPowerButtonPressStatus(VPADChan chan,
+                                  uint32_t tick,
+                                  uint32_t status);
+
+/**
+ * Set the POWER button mode.
+ *
+ * \param chan
+ * The channel of the Gamepad to set the POWER button disable mode to.
+ *
+ * \param mode
+ * Set to 0 to enable and set to 1 to disable.
+ *
+ * \sa
+ * - \link VPADDisablePowerButton \endlink
+ * - \link VPADEnablePowerButton \endlink
+ */
+void
+VPADBASESetPowerButtonDisableMode(VPADChan chan,
+                                  uint32_t mode);
+
+/**
+ * Clear pending IRC events.
+ *
+ * \param chan
+ * The channel of the Gamepad.
+ */
+void
+VPADBASEClearIRCEvent(VPADChan chan);
+
+/**
+ * Get the current IRC status.
+ *
+ * \param chan
+ * The channel of the Gamepad.
+ * 
+ * \returns
+ * The current status flags (see \link VPADIRCStatusFlags \endlink).
+ */
+VPADIRCStatusFlags
+VPADBASEGetIRCStatus(VPADChan chan);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/include/vpadbase/vpadbase.dox
+++ b/include/vpadbase/vpadbase.dox
@@ -1,0 +1,5 @@
+/**
+ * \defgroup vpadbase vpadbase
+ *
+ * Wii U Gamepad base library.
+ */

--- a/libraries/libirc/include/irc/irc.h
+++ b/libraries/libirc/include/irc/irc.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <wut.h>
-#include <vpad/input.h>
+#include <vpadbase/base.h>
 #include <nsysccr/irda.h>
 
 /**

--- a/libraries/libirc/src/cdc.c
+++ b/libraries/libirc/src/cdc.c
@@ -1,7 +1,7 @@
 #include "irc/cdc.h"
 
 #include <nsysccr/irda.h>
-#include <vpad/input.h>
+#include <vpadbase/base.h>
 
 #include <string.h>
 

--- a/tests/test_compile_headers_common/test_compile_headers_list.h
+++ b/tests/test_compile_headers_common/test_compile_headers_list.h
@@ -147,6 +147,7 @@
 #include <sysapp/switch.h>
 #include <sysapp/title.h>
 #include <vpad/input.h>
+#include <vpadbase/base.h>
 #include <wut.h>
 #include <wut_structsize.h>
 #include <wut_types.h>


### PR DESCRIPTION
This separates the `VPADBASE` functions from `vpad/input.h` into their own header.
They're two separate libraries on the system and this change makes this more clear.