### PR TITLE
devoptab_fsa: use c++ headers

### DIFF
--- a/libraries/wutdevoptab/devoptab_fsa.h
+++ b/libraries/wutdevoptab/devoptab_fsa.h
@@ -4,11 +4,13 @@
 #include <coreinit/debug.h>
 #include <coreinit/mutex.h>
 
-#include <errno.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <cstdio>
+
 #include <fcntl.h>
 #include <limits.h>
-#include <stdlib.h>
-#include <string.h>
 #include <malloc.h>
 #include <sys/dirent.h>
 #include <sys/iosupport.h>


### PR DESCRIPTION
Testing with gcc 13 this code is missing header for snprintf. Adding cstdio for that & switching to other c++ headers.