### PR TITLE
coreinit: Add some missing field to the OSThread struct

### DIFF
--- a/include/coreinit/alarm.h
+++ b/include/coreinit/alarm.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <wut.h>
-#include "thread.h"
 #include "threadqueue.h"
 #include "time.h"
+#include "context.h"
 
 /**
  * \defgroup coreinit_alarms Alarms


### PR DESCRIPTION
Most of the fields are coming from [decaf](https://github.com/decaf-emu/decaf-emu/blob/master/src/libdecaf/src/cafe/libraries/coreinit/coreinit_thread.h).

Changes compared to decafs struct:
- the `eh_*` fields have been extracted into a seperate struct. The thread init function does a memset for 0x1D8 bytes at offset 0x3A0, this indicated an own struct. First 0x68 bytes are still unknown.
- `stackSyncObjAllowed` has been added (but is only used on debug builds, and only for logging)
- The final 20 bytes (now defined as `reserved`) are cleared by the thread init functions but never used. These are probably just unused reserved bits.
