### PR TITLE
wutdevoptab: Add support for opening files with more flag combinations

### DIFF
--- a/libraries/wutdevoptab/devoptab_fsa_open.cpp
+++ b/libraries/wutdevoptab/devoptab_fsa_open.cpp
@@ -35,6 +35,12 @@ __wut_fsa_open(struct _reent *r,
       fsMode = "w";
    } else if (((flags & O_ACCMODE) == O_RDWR) && ((flags & commonFlagMask) == (O_CREAT | O_TRUNC))) {
       fsMode = "w+";
+   } else if (((flags & O_ACCMODE) == O_WRONLY) && ((flags & commonFlagMask) == O_CREAT) && (flags & O_EXCL) == O_EXCL) {
+      // if O_EXCL is set, we don't need O_TRUNC
+      fsMode = "w";
+   } else if (((flags & O_ACCMODE) == O_RDWR) && ((flags & commonFlagMask) == O_CREAT) && (flags & O_EXCL) == O_EXCL) {
+      // if O_EXCL is set, we don't need O_TRUNC
+      fsMode = "w+";
    } else if (((flags & O_ACCMODE) == O_WRONLY) && ((flags & commonFlagMask) == (O_CREAT | O_APPEND))) {
       fsMode = "a";
    } else if (((flags & O_ACCMODE) == O_RDWR) && ((flags & commonFlagMask) == (O_CREAT | O_APPEND))) {

--- a/libraries/wutdevoptab/devoptab_fsa_open.cpp
+++ b/libraries/wutdevoptab/devoptab_fsa_open.cpp
@@ -51,6 +51,10 @@ __wut_fsa_open(struct _reent *r,
       // It's not possible to open a file with write only mode which doesn't truncate the file
       // Technically we could read from the file, but our read implementation is blocking this.
       fsMode = "r+";
+   }  else if (((flags & O_ACCMODE) == O_RDWR) && ((flags & commonFlagMask) == (O_CREAT))) {
+      // Cafe OS doesn't have a matching mode for this, so we have to be creative and create the file.
+      createFileIfNotFound = true;
+      fsMode = "r+";
    } else if (((flags & O_ACCMODE) == O_WRONLY) && ((flags & commonFlagMask) == (O_APPEND))) {
       // Cafe OS doesn't have a matching mode for this, so we have to check if the file exists.
       failIfFileNotFound = true;


### PR DESCRIPTION
**(O_EXCL | O_CREAT | O_RDWR) and (O_EXCL | O_CREAT | O_WRONLY)**

Currently every `O_CREAT` needs a `O_TRUNC` as well because Cafe OS truncates the file when opened with `w` and `w+`. When `O_EXCL` is set this doesn't matter because we never touch (truncate) existing files. 

**O_CREAT | O_RDWR**

Very similar to `O_CREAT | O_WRONLY`