### PR TITLE
Use reserved bytes in OSThread structs for wut related thread specifics

### DIFF
--- a/include/coreinit/thread.h
+++ b/include/coreinit/thread.h
@@ -74,9 +74,8 @@ typedef enum OSThreadSpecificID
    OS_THREAD_SPECIFIC_11               = 11,
    OS_THREAD_SPECIFIC_12               = 12,
    OS_THREAD_SPECIFIC_13               = 13,
-   //! These are reserved to wut for internal use
-   OS_THREAD_SPECIFIC_WUT_RESERVED_0   = 14,
-   OS_THREAD_SPECIFIC_WUT_RESERVED_1   = 15,
+   OS_THREAD_SPECIFIC_14               = 14,
+   OS_THREAD_SPECIFIC_15               = 15,
 } OSThreadSpecificID;
 
 enum OS_THREAD_STATE
@@ -324,7 +323,8 @@ struct WUT_ALIGNAS(8) OSThread
    OSExceptionCallbackFn alignCallback[3];
 
    //! Cleared on thread creation but never used
-   uint32_t reserved[5];
+   //! Used as thread specifics for wut for internal usage
+   void* wut_specifics[5];
 };
 #pragma pack(pop)
 WUT_CHECK_OFFSET(OSThread, 0x320, tag);
@@ -376,7 +376,7 @@ WUT_CHECK_OFFSET(OSThread, 0x66c, fastMutex);
 WUT_CHECK_OFFSET(OSThread, 0x670, contendedFastMutexes);
 WUT_CHECK_OFFSET(OSThread, 0x678, fastMutexQueue);
 WUT_CHECK_OFFSET(OSThread, 0x680, alignCallback);
-WUT_CHECK_OFFSET(OSThread, 0x68c, reserved);
+WUT_CHECK_OFFSET(OSThread, 0x68c, wut_specifics);
 WUT_CHECK_SIZE(OSThread, 0x6a0);
 
 /**

--- a/libraries/wutnewlib/wut_thread_specific.c
+++ b/libraries/wutnewlib/wut_thread_specific.c
@@ -1,0 +1,22 @@
+#include "wut_thread_specific.h"
+#include <coreinit/thread.h>
+#include <wut.h>
+
+void wut_set_thread_specific(__wut_thread_specific_id id, void *value) {
+   OSThread *thread = OSGetCurrentThread();
+   if (thread != NULL && id >= WUT_THREAD_SPECIFIC_0 && id <= WUT_THREAD_SPECIFIC_4) {
+      thread->wut_specifics[id] = value;
+   } else {
+      WUT_DEBUG_REPORT("wut_set_thread_specific: invalid thread or id\n");
+   }
+}
+
+void *wut_get_thread_specific(__wut_thread_specific_id id) {
+   OSThread *thread = OSGetCurrentThread();
+   if (thread != NULL && id >= WUT_THREAD_SPECIFIC_0 && id <= WUT_THREAD_SPECIFIC_4) {
+      return thread->wut_specifics[id];
+   } else {
+      WUT_DEBUG_REPORT("wut_get_thread_specific: invalid thread or id\n");
+   }
+   return NULL;
+}

--- a/libraries/wutnewlib/wut_thread_specific.h
+++ b/libraries/wutnewlib/wut_thread_specific.h
@@ -1,0 +1,21 @@
+#pragma once
+
+typedef enum __wut_thread_specific_id {
+    WUT_THREAD_SPECIFIC_0 = 0,
+    WUT_THREAD_SPECIFIC_1 = 1,
+    WUT_THREAD_SPECIFIC_2 = 2,
+    WUT_THREAD_SPECIFIC_3 = 3,
+    WUT_THREAD_SPECIFIC_4 = 4,
+} __wut_thread_specific_id;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void wut_set_thread_specific(__wut_thread_specific_id id, void *value);
+
+void *wut_get_thread_specific(__wut_thread_specific_id id);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libraries/wutstdc++/wut_gthread.h
+++ b/libraries/wutstdc++/wut_gthread.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <bits/gthr-default.h>
-
+#include "../wutnewlib/wut_thread_specific.h"
 #include <coreinit/atomic.h>
 #include <coreinit/condition.h>
 #include <coreinit/thread.h>
@@ -13,7 +13,7 @@
 #define __WUT_ONCE_VALUE_STARTED (1)
 #define __WUT_ONCE_VALUE_DONE (2)
 
-#define __WUT_KEY_THREAD_SPECIFIC_ID OS_THREAD_SPECIFIC_WUT_RESERVED_0
+#define __WUT_KEY_THREAD_SPECIFIC_ID WUT_THREAD_SPECIFIC_0
 
 typedef volatile uint32_t __wut_once_t;
 typedef struct {

--- a/libraries/wutstdc++/wut_gthread_keys.cpp
+++ b/libraries/wutstdc++/wut_gthread_keys.cpp
@@ -59,7 +59,7 @@ __wut_key_delete(__wut_key_t key)
 static const void **
 __wut_get_thread_keys()
 {
-   const void **keys = (const void **)OSGetThreadSpecific(__WUT_KEY_THREAD_SPECIFIC_ID);
+   const void **keys = (const void **)wut_get_thread_specific(__WUT_KEY_THREAD_SPECIFIC_ID);
    if (!keys) {
       keys = (const void **)malloc(sizeof(void *) * sizeof(__WUT_MAX_KEYS));
       if (!keys) {
@@ -67,7 +67,7 @@ __wut_get_thread_keys()
       }
 
       memset(keys, 0, sizeof(void *) * sizeof(__WUT_MAX_KEYS));
-      OSSetThreadSpecific(__WUT_KEY_THREAD_SPECIFIC_ID, keys);
+      wut_set_thread_specific(__WUT_KEY_THREAD_SPECIFIC_ID, keys);
    }
 
    return keys;
@@ -100,7 +100,7 @@ __wut_setspecific(__wut_key_t key,
 void
 __wut_key_cleanup(OSThread *thread)
 {
-   void **keys = (void **)OSGetThreadSpecific(__WUT_KEY_THREAD_SPECIFIC_ID);
+   void **keys = (void **)wut_get_thread_specific(__WUT_KEY_THREAD_SPECIFIC_ID);
    if (!keys) {
       return;
    }


### PR DESCRIPTION
Open for discussion.

Recently `__wut_getreent` got implemented which uses `OSGetThreadSpecific`/`OSSetThreadSpecific` to store some thread specific data. This works fine for regular homebrew, but for WUPS/WUMS (Plugin/Module system) we might end up using a reent within a (Cafe OS) thread we do not control (e.g. due to function replacing/patching). In this case using/overriding the "regular" thread specifics might then result in undefined behaviour. To avoid this I propose to the use the ["reserved" bytes](https://github.com/Maschell/wut/blob/f477ccaa9a6d4cbc4cc08446e5dbb5de7493bb64/include/coreinit/thread.h#L305) of the OSThread struct for custom thread specifics which are exclusively reserved for wut.

Contra:
- Using the reserved bytes is/feels quite hacky. Forcing every homebrew do this this feels even more hacky.
- If Nintendo drops an update and decides to use this reserved bytes all homebrew break

Pro:
- wut homebrew can again use all "regular" thread specifcs
- Using these reserved bytes is documented in wut. If this won't get merged I probably end up using the bytes anyway for WUPS/WUMS, but then it's less obvious they are actually used by something.
- We won't need separate `getreent` implementations for WUPS/WUMS.
- 
I am personally not really sure how to fix it. Using these reserved bytes feels indeed very hacky but seems overall to be the easiest and cleanest solution.