### PR TITLE
Add missing optnames and multicast support

### DIFF
--- a/cafe/nsysnet.def
+++ b/cafe/nsysnet.def
@@ -123,6 +123,7 @@ inet_ntoa
 inet_ntoa_r
 ntohl
 ntohs
+set_multicast_state
 socket_lib_finish
 socket_lib_init
 
@@ -162,7 +163,6 @@ send
 sendto
 sendto_multi
 sendto_multi_ex
-set_multicast_state
 set_resolver_allocator
 setsocklibopt
 setsockopt

--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -15,17 +15,31 @@
 
 #define IP_TOS             3
 #define IP_TTL             4
+#define IP_MULTICAST_IF    9
+#define IP_MULTICAST_TTL   10
+#define IP_MULTICAST_LOOP  11
+#define IP_ADD_MEMBERSHIP  12
+#define IP_DROP_MEMBERSHIP 13
+#define IP_UNKNOWN         14
 
 typedef uint16_t in_port_t;
 typedef uint32_t in_addr_t;
 
-struct in_addr {
-	in_addr_t       s_addr;
+struct in_addr
+{
+   in_addr_t       s_addr;
 };
 
-struct sockaddr_in {
-	sa_family_t     sin_family;
-	in_port_t       sin_port;
-	struct in_addr  sin_addr;
-	unsigned char   sin_zero[8];
+struct sockaddr_in
+{
+   sa_family_t     sin_family;
+   in_port_t       sin_port;
+   struct in_addr  sin_addr;
+   unsigned char   sin_zero[8];
+};
+
+struct ip_mreq
+{
+   struct in_addr imr_multiaddr;
+   struct in_addr imr_interface;
 };

--- a/include/netinet/tcp.h
+++ b/include/netinet/tcp.h
@@ -6,3 +6,4 @@
 #define TCP_NOACKDELAY     0x2002
 #define TCP_MAXSEG         0x2003
 #define TCP_NODELAY        0x2004
+#define TCP_UNKNOWN        0x2005   // amount of mss received before sending an ack

--- a/include/nsysnet/misc.h
+++ b/include/nsysnet/misc.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup nsysnet_misc
+ * \ingroup nsysnet
+ * @{
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int
+set_multicast_state(BOOL multicastEnable);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -27,6 +27,7 @@
  */
 #define SO_REUSEADDR    0x0004      // reuse address
 #define SO_KEEPALIVE    0x0008      // keep connections alive
+#define SO_DONTROUTE    0x0010      // route locally only
 #define SO_BROADCAST    0x0020      // broadcast
 #define SO_LINGER       0x0080      // linger (no effect?)
 #define SO_OOBINLINE    0x0100      // out-of-band data inline (no effect?)
@@ -36,13 +37,21 @@
 #define SO_RCVBUF       0x1002      // receive buffer size
 #define SO_SNDLOWAT     0x1003      // send low-water mark (no effect?)
 #define SO_RCVLOWAT     0x1004      // receive low-water mark
+#define SO_ERROR        0x1007      // get socket error
 #define SO_TYPE         0x1008      // get socket type
-#define SO_ERROR        0x1009      // get socket error
+#define SO_HOPCNT       0x1009      // get hop count
+#define SO_MAXMSG       0x1010      // same as TCP_MAXSEG
 #define SO_RXDATA       0x1011      // get count of bytes in sb_rcv
 #define SO_TXDATA       0x1012      // get count of bytes in sb_snd
+#define SO_MYADDR       0x1013      // get IP address
 #define SO_NBIO         0x1014      // set socket to NON-blocking mode
 #define SO_BIO          0x1015      // set socket to blocking mode
 #define SO_NONBLOCK     0x1016      // set/get blocking mode via optval param
+#define SO_UNKNOWN1019  0x1019      // tcp related
+#define SO_UNKNOWN101A  0x101A      // tcp related
+#define SO_UNKNOWN101B  0x101B      // tcp related
+#define SO_NOSLOWSTART  0x4000      // disable slowstart
+#define SO_RUSRBUF      0x10000     // ?
 
 typedef uint32_t socklen_t;
 typedef uint16_t sa_family_t;

--- a/libraries/wutsocket/wut_socket_common.c
+++ b/libraries/wutsocket/wut_socket_common.c
@@ -1,4 +1,5 @@
 #include "wut_socket.h"
+#include <nsysnet/misc.h>
 
 #define NSYSNET_UNKNOWN_ERROR_OFFSET 10000
 
@@ -88,6 +89,7 @@ void __attribute__((weak))
 __init_wut_socket()
 {
    socket_lib_init();
+   set_multicast_state(TRUE);
    __wut_socket_init_devoptab();
    ACInitialize();
    ACConnectAsync();

--- a/tests/test_compile_headers_common/test_compile_headers_list.h
+++ b/tests/test_compile_headers_common/test_compile_headers_list.h
@@ -130,6 +130,7 @@
 #include <nsysccr/irda.h>
 #include <nsyshid/hid.h>
 #include <nsysnet/_socket.h>
+#include <nsysnet/misc.h>
 #include <nsysnet/netconfig.h>
 #include <nsysnet/nssl.h>
 #include <nsysuhs/uhs.h>


### PR DESCRIPTION
This adds a define for all `setsockopt`/`getsockopt` optnames supported on the IOSU-side implementation, which includes support for multicast. 
Calling `set_multicast_state(TRUE)` is required for sending multicasts, otherwise `bind` and `sendto` fail with `ENETUNREACH` for multicast addresses.