### PR TITLE
Finalize compile commands

### DIFF
--- a/share/wut_rules
+++ b/share/wut_rules
@@ -75,6 +75,7 @@ endif
 #---------------------------------------------------------------------------------
 %.elf:
 	@echo linking ... $(notdir $@)
+	$(ADD_COMPILE_COMMAND) end
 	$(SILENTCMD)$(LD) $(LDFLAGS) $(OFILES) $(LIBPATHS) $(LIBS) -o $@ $(ERROR_FILTER)
 	$(SILENTCMD)$(NM) -CSn $@ > $(notdir $*.lst) $(ERROR_FILTER)
 


### PR DESCRIPTION
When using the make option `GENERATE_COMPILE_COMMANDS=1`, it will generate the compile commands database but never run the `end` command, so the filename will be stuck as `compile_commands.part`. This change fixes it so `compile_commands.json` is the final filename.

I referenced how it's done for 3DS: https://github.com/devkitPro/devkitarm-rules/blob/ab0f5c46edaf0d3e7d582bf0e66430dbde92a902/3ds_rules#L43