### PR TITLE
Add missing language/region values to nn::erreula and nn::swkbd

### DIFF
--- a/include/nn/erreula/erreula_cpp.h
+++ b/include/nn/erreula/erreula_cpp.h
@@ -41,9 +41,19 @@ enum class ErrorType
 
 enum class LangType
 {
-   Japanese          = 0,
-   English           = 1,
-   // TODO: More languages
+   Japanese           = 0,
+   English            = 1,
+   French             = 2,
+   German             = 3,
+   Italian            = 4,
+   Spanish            = 5,
+   SimplifiedChinese  = 6,
+   Korean             = 7,
+   Dutch              = 8,
+   Portuguese         = 9,
+   Russian            = 10,
+   TraditionalChinese = 11,
+   Invalid            = 12,
 };
 
 enum class RegionType

--- a/include/nn/swkbd/swkbd_cpp.h
+++ b/include/nn/swkbd/swkbd_cpp.h
@@ -52,12 +52,12 @@ enum class LanguageType
    German             = 3,
    Italian            = 4,
    Spanish            = 5,
-   TraditionalChinese = 6,
+   SimplifiedChinese  = 6,
    Korean             = 7,
    Dutch              = 8,
    Portuguese         = 9,
    Russian            = 10,
-   SimplifiedChinese  = 11,
+   TraditionalChinese = 11,
    Invalid            = 12,
 };
 
@@ -66,7 +66,9 @@ enum class RegionType
    Japan    = 0,
    USA      = 1,
    Europe   = 2,
-   //! TODO: find more region types
+   China    = 3,
+   Korea    = 4,
+   Taiwan   = 5,
 };
 
 enum class State

--- a/include/nn/swkbd/swkbd_cpp.h
+++ b/include/nn/swkbd/swkbd_cpp.h
@@ -44,19 +44,32 @@ enum class ControllerType
    DrcGamepad  = 4,
 };
 
+//! If the LanguageType and RegionType are not compatible, the LanguageType will be set to English, unless the RegionType is set to "Japan," in which case the LanguageType will be set to Japanese.
 enum class LanguageType
 {
+   //! Must be used in combination with RegionType::Japan
    Japanese           = 0,
+   //! Must be used in combination with RegionType::USA or RegionType::Europe
    English            = 1,
+   //! Must be used in combination with RegionType::USA or RegionType::Europe
    French             = 2,
+   //! Must be used in combination with RegionType::Europe
    German             = 3,
+   //! Must be used in combination with RegionType::Europe
    Italian            = 4,
+   //! Must be used in combination with RegionType::USA or RegionType::Europe
    Spanish            = 5,
+   //! Must be used in combination with RegionType::China
    SimplifiedChinese  = 6,
+   //! Must be used in combination with RegionType::Korea
    Korean             = 7,
+   //! Must be used in combination with RegionType::Europe
    Dutch              = 8,
+   //! Must be used in combination with RegionType::USA or RegionType::Europe
    Portuguese         = 9,
+   //! Must be used in combination with RegionType::Europe
    Russian            = 10,
+   //! Must be used in combination with RegionType::Taiwan
    TraditionalChinese = 11,
    Invalid            = 12,
 };


### PR DESCRIPTION
See title. Values taken from [Cemu](https://github.com/cemu-project/Cemu/blob/f3c95f72e74d8a5f5873061fbb994643c63ec9c5/src/config/CemuConfig.h#L158) and reverse engineering nn::swkd (e.g. for the restricted nn::swbkd LanguageType/RegionType values)

See: #335 