### PR TITLE
wutnewlib: implement abort, assert and assert_func

### DIFF
--- a/libraries/wutnewlib/wut_newlib.c
+++ b/libraries/wutnewlib/wut_newlib.c
@@ -32,9 +32,9 @@ __assert_func(const char *file,
    char tmp[512] = {};
    char buffer[512] = {};
 
-   snprintf(tmp, sizeof(tmp), "assertion \"%s\" failed:\n file \"%s\", line %d%s%s",
-            failedexpr, file, line,
-            func ? ", function: " : "", func ? func : "");
+   __os_snprintf(tmp, sizeof(tmp), "assertion \"%s\" failed:\n file \"%s\", line %d%s%s",
+                 failedexpr, file, line,
+                 func ? ", function: " : "", func ? func : "");
 
    // make sure to add a \n every 64 characters to fit on the DRC screen.
    char *target_ptr = buffer;


### PR DESCRIPTION
Provides custom abort and assert_func implementation to display some text on the screen (and gamepad). Previously a failed assertion (or calling abort) would just softlock the console without giving the user/dev any form of feedback.
