### PR TITLE
wutdevoptab: implement __wut_fsa_get_stat_from_dir to allow optimized implemenation of readdir that avoid an addtional stat

### DIFF
--- a/libraries/wutdevoptab/devoptab_fsa.h
+++ b/libraries/wutdevoptab/devoptab_fsa.h
@@ -125,6 +125,8 @@ mode_t __wut_fsa_translate_stat_mode(FSStat *fsStat);
 void __wut_fsa_translate_stat(FSAClientHandle handle, FSStat *fsStat, ino_t ino, struct stat *posStat);
 uint32_t __wut_fsa_hashstring(const char *str);
 
+bool __wut_fsa_get_stat_from_dir(DIR *dp, struct stat *posStat);
+
 static inline FSMode __wut_fsa_translate_permission_mode(mode_t mode) {
    // Convert normal Unix octal permission bits into CafeOS hexadecimal permission bits
    return (FSMode) (((mode & S_IRWXU) << 2) | ((mode & S_IRWXG) << 1) | (mode & S_IRWXO));

--- a/libraries/wutdevoptab/devoptab_fsa_dirnext.cpp
+++ b/libraries/wutdevoptab/devoptab_fsa_dirnext.cpp
@@ -20,7 +20,7 @@ __wut_fsa_dirnext(struct _reent *r,
    dir = (__wut_fsa_dir_t *) (dirState->dirStruct);
 
    std::scoped_lock lock(dir->mutex);
-   memset(&dir->entry_data, 0, sizeof(dir->entry_data));
+   dir->entry_data = {};
 
    status = FSAReadDir(deviceData->clientHandle, dir->fd, &dir->entry_data);
    if (status < 0) {

--- a/libraries/wutdevoptab/devoptab_fsa_diropen.cpp
+++ b/libraries/wutdevoptab/devoptab_fsa_diropen.cpp
@@ -48,6 +48,6 @@ __wut_fsa_diropen(struct _reent *r,
 
    dir->magic = FSA_DIRITER_MAGIC;
    dir->fd = fd;
-   memset(&dir->entry_data, 0, sizeof(dir->entry_data));
+   dir->entry_data = {};
    return dirState;
 }

--- a/libraries/wutdevoptab/devoptab_fsa_utils.cpp
+++ b/libraries/wutdevoptab/devoptab_fsa_utils.cpp
@@ -193,6 +193,22 @@ void __wut_fsa_translate_stat(FSAClientHandle clientHandle, FSStat *fsStat, ino_
    posStat->st_blocks = (posStat->st_size + posStat->st_blksize - 1) / posStat->st_size;
 }
 
+bool
+__wut_fsa_get_stat_from_dir(DIR *dp, struct stat *posStat) {
+   if (dp == NULL || dp->dirData == NULL || dp->dirData->dirStruct == NULL || posStat == NULL) {
+      return false;
+   }
+
+   auto const magic = *(uint32_t * )(dp->dirData->dirStruct);
+   if (magic == FSA_DIRITER_MAGIC) {
+      __wut_fsa_dir_t *dir = (__wut_fsa_dir_t *) dp->dirData->dirStruct;
+      __wut_fsa_translate_stat(0, &dir->entry_data.info, 0, posStat);
+      return true;
+   }
+
+   return false;
+}
+
 int __wut_fsa_translate_error(FSError error) {
    switch (error) {
       case FS_ERROR_END_OF_DIR:


### PR DESCRIPTION
In the FAT32 driver that is used on the Wii U  each `readdir` and  `stat` can be really slow, Especially in directory with many files. This functions helps dev to avoid `stat` calls in a readdir loop by reading the current dir entry from the DIR*.

Example usage:
```
std::string dirPath = "fs:/vol/external01";
DIR* dir = opendir(dirPath.c_str());
if (dir)
{
  struct dirent *ent;
  while ((ent = readdir (dir)) != NULL)
  {
    struct stat st = {};
    if (!__wut_fsa_get_stat_from_dir (dir, &st))
    {
      std::string fullpath = dirPath + "/" + ent->d_name;
      ::stat (fullpath.c_str(), &st);
    }
    OSReport ("\"%s\" size: %lld bytes\n ", ent->d_name, st.st_size);
  }
  closedir (dir);
}
```

Benchmarks (tested by listing the dir via ftp, so all numbers include an overhead, but I only cared of the relative not absolute numbers)
(Already using [mocha 0.3.0-dev](https://github.com/wiiu-env/MochaPayload/tree/0.3.0-dev) with experimental fs patches)
```
Directory 1, 1000 files, each file has a very long and similar name e.g. `this_is_a_normal_filename_but_long_0atcpsdz.xvg`:
     with addtional stat: 125.883 sec
 without additional stat: 1.814 sec

Directory 2, 1000 files, each file has a unique and short name (e.g. `0b2vj3w4.2nl`):
    with addtional stat: 7.747
without additional stat: 1.383 sec
```

I know this is not very clean and not a very optimal solution, but the impact is really huge if you look at the benchmarks. I would rather have this helper function inside wut than having it in each homebrew app.