### PR TITLE
docs: Bump runner version

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   doc:
     name: Deploy documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
 


### PR DESCRIPTION
The Doxygen version packaged for ubuntu-20.04 seems to cause some preprocessing bugs.