### PR TITLE
A little more padscore

### DIFF
--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -76,7 +76,7 @@ WUT_CHECK_OFFSET(KPADVec3D, 0x04, y);
 WUT_CHECK_OFFSET(KPADVec3D, 0x08, z);
 WUT_CHECK_SIZE(KPADVec3D, 0x0C);
 
-//! A structure conataining the Wii Remote data.
+//! A structure containing the Wii Remote data.
 struct KPADStatus
 {
    //! Indicates what KPADButtons are held down.
@@ -139,7 +139,7 @@ struct KPADStatus
          uint32_t trigger;
          //! Indicates what buttons have been released since last sample.
          uint32_t release;
-      } nunchuck;
+      } nunchuk;
 
       //! Structure to use when extension type is set to \link WPAD_EXT_CLASSIC \endlink.
       struct
@@ -197,13 +197,13 @@ WUT_CHECK_OFFSET(KPADStatus, 0x5D, error);
 WUT_CHECK_OFFSET(KPADStatus, 0x5E, posValid);
 WUT_CHECK_OFFSET(KPADStatus, 0x5F, format);
 // For WPAD_EXT_NUNCHUK
-WUT_CHECK_OFFSET(KPADStatus, 0x60, nunchuck.stick);
-WUT_CHECK_OFFSET(KPADStatus, 0x68, nunchuck.acc);
-WUT_CHECK_OFFSET(KPADStatus, 0x74, nunchuck.accMagnitude);
-WUT_CHECK_OFFSET(KPADStatus, 0x78, nunchuck.accVariation);
-WUT_CHECK_OFFSET(KPADStatus, 0x7C, nunchuck.hold);
-WUT_CHECK_OFFSET(KPADStatus, 0x80, nunchuck.trigger);
-WUT_CHECK_OFFSET(KPADStatus, 0x84, nunchuck.release);
+WUT_CHECK_OFFSET(KPADStatus, 0x60, nunchuk.stick);
+WUT_CHECK_OFFSET(KPADStatus, 0x68, nunchuk.acc);
+WUT_CHECK_OFFSET(KPADStatus, 0x74, nunchuk.accMagnitude);
+WUT_CHECK_OFFSET(KPADStatus, 0x78, nunchuk.accVariation);
+WUT_CHECK_OFFSET(KPADStatus, 0x7C, nunchuk.hold);
+WUT_CHECK_OFFSET(KPADStatus, 0x80, nunchuk.trigger);
+WUT_CHECK_OFFSET(KPADStatus, 0x84, nunchuk.release);
 // For WPAD_EXT_CLASSIC
 WUT_CHECK_OFFSET(KPADStatus, 0x60, classic.hold);
 WUT_CHECK_OFFSET(KPADStatus, 0x64, classic.trigger);

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -328,12 +328,13 @@ KPADSetConnectCallback(KPADChan chan,
 
 /**
  * Sets MotionPlus for the controller in specified mode
- * \sa
- * - KPADMotionPlusMode
+ * 
+ * \param mode
+ * The MotionPlus mode which should be used
  */
 void
 KPADEnableMpls(KPADChan channel,
-               uint8_t mode);
+               KPADMotionPlusMode mode);
 
 /**
  * Disables MotionPlus for the controller

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -325,7 +325,9 @@ KPADSetConnectCallback(KPADChan chan,
  * Sets MotionPlus for the controller in specified mode
  * 
  * \param mode
- * The MotionPlus mode which should be used
+ * The MotionPlus mode which should be used, the mode may be ignored and a different mode used,
+ * usually because the required extension is not connected. Make sure to check result with
+ * \link KPADGetMplsStatus \endlink
  */
 void
 KPADEnableMpls(KPADChan channel,

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -20,6 +20,8 @@ typedef enum WPADChan KPADChan;
 typedef enum WPADDataFormat KPADDataFormat;
 //! Extension type.
 typedef enum WPADExtensionType KPADExtensionType;
+//! MotionPlus Mode.
+typedef enum WPADMplsMode KPADMplsMode;
 
 typedef struct KPADStatus KPADStatus;
 typedef struct KPADVec2D KPADVec2D;
@@ -41,13 +43,6 @@ typedef enum KPADError
    //! KPAD is uninitialized, need to call KPADInit()
    KPAD_ERROR_UNINITIALIZED      = -5,
 } KPADError;
-
-//! MotionPlus Mode.
-typedef enum KPADMotionPlusMode
-{
-    KPAD_MPLS_MODE_DISABLE = 0,
-    KPAD_MPLS_MODE_ENABLE = 4,
-} KPADMotionPlusMode;
 
 //! 2D vector.
 struct KPADVec2D
@@ -334,13 +329,33 @@ KPADSetConnectCallback(KPADChan chan,
  */
 void
 KPADEnableMpls(KPADChan channel,
-               KPADMotionPlusMode mode);
+               KPADMplsMode mode);
 
 /**
  * Disables MotionPlus for the controller
  */
 void
 KPADDisableMpls(KPADChan channel);
+
+/**
+ * Get MotionPlus mode
+ *
+ * identical to \ref WPADiGetMplsStatus
+ */
+KPADMplsMode
+KPADGetMplsStatus(KPADChan chan);
+
+/**
+ * Enable IR pointing
+ */
+void
+KPADEnableDPD(KPADChan chan);
+
+/**
+ * Disable IR pointing
+ */
+void
+KPADDisableDPD(KPADChan chan);
 
 #ifdef __cplusplus
 }

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -42,6 +42,13 @@ typedef enum KPADError
    KPAD_ERROR_UNINITIALIZED      = -5,
 } KPADError;
 
+//! MotionPlus Mode.
+typedef enum KPADMotionPlusMode
+{
+    KPAD_MPLS_MODE_DISABLE = 0,
+    KPAD_MPLS_MODE_ENABLE = 4,
+} KPADMotionPlusMode;
+
 //! 2D vector.
 struct KPADVec2D
 {
@@ -275,10 +282,10 @@ KPADReadEx(KPADChan chan,
 
 /**
  * Set the maximum amount of controllers which can be connected to the system.
- * 
+ *
  * \param maxControllers
  * The maximum amount of controllers. Must be \c 4 or \c 7.
- * 
+ *
  * \return
  * 0 on success.
  */
@@ -287,7 +294,7 @@ KPADSetMaxControllers(uint32_t maxControllers);
 
 /**
  * Get the maximum amount of controllers which can be connected to the system.
- * 
+ *
  * \return
  * The maximum amount of controllers.
  */
@@ -296,7 +303,7 @@ KPADGetMaxControllers(void);
 
 /**
  * Get the maximum amount of controllers which can be connected, as reported by IOS-PAD.
- * 
+ *
  * \return
  * The maximum amount of controllers.
  */
@@ -311,13 +318,28 @@ KPADGetGameMaxControllers(void);
  *
  * \param callback
  * Pointer to a callback function.
- * 
+ *
  * \return
  * The previous connect callback.
  */
 KPADConnectCallback
 KPADSetConnectCallback(KPADChan chan,
                        KPADConnectCallback callback);
+
+/**
+ * Sets MotionPlus for the controller in specified mode
+ * \sa
+ * - KPADMotionPlusMode
+ */
+void
+KPADEnableMpls(KPADChan channel,
+               uint8_t mode);
+
+/**
+ * Disables MotionPlus for the controller
+ */
+void
+KPADDisableMpls(KPADChan channel);
 
 #ifdef __cplusplus
 }

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -17,6 +17,7 @@ extern "C" {
 typedef struct WPADStatusProController WPADStatusProController;
 typedef struct WPADVec2D WPADVec2D;
 typedef struct WPADInfo WPADInfo;
+typedef struct WPADAddress WPADAddress;
 typedef struct WPADiQueueElement WPADiQueueElement;
 typedef struct WPADiQueue WPADiQueue;
 
@@ -778,7 +779,7 @@ WPADStartSyncDevice();
  * WPADAddress addr;
  * memset(&addr, 0, 6);
  * // Will search for controllers with any address and a name that starts with "Nintendo"
- * WPADStartSyncDevice(addr, "Nintendo");
+ * WPADStartSyncDeviceEx(addr, "Nintendo");
  * \endcode
  */
 BOOL
@@ -969,17 +970,18 @@ WPADiGetGameType();
 
 /**
  * Sets game title for all connected controllers
- * \param title up to 17 characters including null terminator
+ * \param title up to 17 UTF-16 characters including null terminator
  * title will be copied onto the controller EEPROM
  * \sa
  * - WPADGetGameTitleUtf16
  * - WPADiWriteGameData
  */
 void
-WPADSetGameTitleUtf16(char16_t* title);
+WPADSetGameTitleUtf16(uint16_t* title);
 
 /**
  * Gets game title stored on specified controller
+ * \param outTitle pointer to where the title will be output
  * \returns -4, if game data previously failed to write
  * \sa
  * - WPADSetGameTitleUtf16
@@ -987,7 +989,7 @@ WPADSetGameTitleUtf16(char16_t* title);
  */
 int32_t
 WPADGetGameTitleUtf16(WPADChan chan,
-                      char16_t** outTitle);
+                      uint16_t** outTitle);
 
 /**
  * Get the time that game data was written

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -241,7 +241,7 @@ typedef enum WPADPeripheral {
     MOTIONPLUS = 0xA6,
     //! Infrared
     DPD        = 0xB0
-} WPADPeripheral;
+} WPADPeripheralSpace;
 
 //! 2D vector.
 struct WPADVec2D
@@ -348,7 +348,7 @@ WPADControlMotor(WPADChan chan,
 int32_t 
 WPADIsMplsAttached(WPADChan channel, 
                   BOOL *attachedOut, 
-                  WPADCallback callback);
+                  WPADIsMplsAttachedCallback callback);
 
 
 /**
@@ -454,7 +454,7 @@ void
 WPADEnableWiiRemote(BOOL enable);
 
 void
-WPADSetAutoSleepTime(BOOL time);
+WPADSetAutoSleepTime(uint8_t time);
 
 
 WPADConnectCallback

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -95,6 +95,8 @@ typedef enum WPADExtensionType
    WPAD_EXT_MPLUS_CLASSIC           = 7,
    //! Pro Controller.
    WPAD_EXT_PRO_CONTROLLER          = 31,
+   //! No controller found.
+   WPAD_EXT_DEV_NOT_FOUND           = 253
 } WPADExtensionType;
 
 //! Wii Remote buttons.

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -267,6 +267,9 @@ WPADInit();
 void
 WPADShutdown();
 
+void
+WPADDisconnect(WPADChan chan);
+
 int32_t
 WPADProbe(WPADChan chan,
           WPADExtensionType *outExtensionType);
@@ -274,12 +277,6 @@ WPADProbe(WPADChan chan,
 int32_t
 WPADSetDataFormat(WPADChan chan,
                   WPADDataFormat format);
-
-void
-WPADEnableURCC(int32_t enable);
-
-void
-WPADEnableWiiRemote(int32_t enable);
 
 void
 WPADRead(WPADChan chan,
@@ -293,10 +290,14 @@ WPADControlMotor(WPADChan chan,
                  BOOL motorEnabled);
 
 void
-WPADSetAutoSleepTime(uint8_t time);
+WPADEnableURCC(BOOL enable);
 
 void
-WPADDisconnect(WPADChan chan);
+WPADEnableWiiRemote(BOOL enable);
+
+void
+WPADSetAutoSleepTime(BOOL time);
+
 
 WPADConnectCallback
 WPADSetConnectCallback(WPADChan chan,

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -273,21 +273,22 @@ typedef enum WPADDpdMode
 //! WPAD Speaker Mode.
 typedef enum WPADSpeakerMode
 {
-    OFF = 0,
-    ON = 1,
-    MUTE = 2,
-    UNMUTE = 3
+    WPAD_SPEAKER_OFF    = 0,
+    WPAD_SPEAKER_ON     = 1,
+    WPAD_SPEAKER_MUTE   = 2,
+    WPAD_SPEAKER_UNMUTE = 3
 } WPADSpeakerMode;
 
 
 //! WPAD Peripheral Memory Space Prefixes
 typedef enum WPADPeripheralSpace
 {
-    SPEAKER    = 0xA2,
-    EXTENSION  = 0xA4,
-    MOTIONPLUS = 0xA6,
+    WPAD_PERIPHERAL_SPACE_SPEAKER     = 0xA2,
+    //! Any extension other than Motion Plus
+    WPAD_PERIPHERAL_SPACE_EXTENSION   = 0xA4,
+    WPAD_PERIPHERAL_SPACE_MOTIONPLUS  = 0xA6,
     //! Infrared
-    DPD        = 0xB0
+    WPAD_PERIPHERAL_SPACE_DPD         = 0xB0
 } WPADPeripheralSpace;
 
 //! 2D vector.

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -636,6 +636,27 @@ WPADIsMotorEnabled();
 void
 WPADEnableURCC(BOOL enable);
 
+/**
+ * Returns whether Wii U Pro Controllers are supported
+ */
+BOOL
+WPADIsEnabledURC();
+
+/**
+ * Enables/disables Wii Balance Board support
+ */
+void
+WPADEnableWBC(BOOL enable);
+
+/**
+ * Returns whether Wii Balance Boards are supported
+ */
+BOOL
+WPADIsEnableWBC();
+
+/**
+ * Enables/disables Wii Remote support
+ */
 void
 WPADEnableWiiRemote(BOOL enable);
 

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -273,10 +273,18 @@ typedef enum WPADDpdMode
 //! WPAD Speaker Mode.
 typedef enum WPADSpeakerMode
 {
-    WPAD_SPEAKER_OFF    = 0,
-    WPAD_SPEAKER_ON     = 1,
-    WPAD_SPEAKER_MUTE   = 2,
-    WPAD_SPEAKER_UNMUTE = 3
+    //! Deinitializes and turns off speaker
+    WPAD_SPEAKER_OFF            = 0,
+    //! Turns on, initializes and mutes speaker
+    WPAD_SPEAKER_ON             = 1,
+    //! Mutes speaker
+    WPAD_SPEAKER_MUTE           = 2,
+    //! Unmutes speaker
+    WPAD_SPEAKER_UNMUTE         = 3,
+    //! Allows audio to play, use after setting WPAD_SPEAKER_ON and before playing sound
+    WPAD_SPEAKER_FINISH_INIT    = 4,
+    //! Does the same as WPAD_SPEAKER_ON
+    WPAD_SPEAKER_ON_ALT         = 5
 } WPADSpeakerMode;
 
 //! MotionPlus Mode.
@@ -473,6 +481,19 @@ int32_t
 WPADSendStreamData(WPADChan chan,
                    void* data,
                    uint32_t size);
+
+/**
+ * Returns the global Wii Remote speaker volume
+ */
+uint8_t
+WPADGetSpeakerVolume();
+
+/**
+ * Sets the global Wii Remote speaker volume
+ * only applies to later initialized Wii Remote speakers
+ */
+void
+WPADSetSpeakerVolume(uint8_t volume);
 
 /**
  * Gets whether MotionPlus is enabled for the WPAD

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -267,31 +267,32 @@ typedef enum WPADLed
 } WPADLed;
 WUT_ENUM_BITMASK_TYPE(WPADLed);
 
-//!  WPAD Infrared Mode. For more information see <a href="https://wiibrew.org/wiki/Wiimote#Data_Formats">IR Data Formats</a>
-typedef enum WPADDpdMode
+//!  WPAD Infrared Format. For more information see <a href="https://wiibrew.org/wiki/Wiimote#Data_Formats">IR Data Formats</a>
+typedef enum WPADDpdFormat
 {
-    WPAD_DPD_DISABLE = 0,
-    WPAD_DPD_ENABLE_BASIC = 1,
-    WPAD_DPD_ENABLE_EXTENDED = 3,
-    WPAD_DPD_ENABLE_FULL = 5
-} WPADDpdMode;
+    //! Disable IR
+    WPAD_DPD_FMT_NONE = 0,
+    WPAD_DPD_FMT_BASIC = 1,
+    WPAD_DPD_FMT_EXTENDED = 3,
+    WPAD_DPD_FMT_FULL = 5
+} WPADDpdFormat;
 
-//! WPAD Speaker Mode.
-typedef enum WPADSpeakerMode
+//! WPAD Speaker Command.
+typedef enum WPADSpeakerCmd
 {
     //! Deinitializes and turns off speaker
-    WPAD_SPEAKER_OFF            = 0,
+    WPAD_SPEAKER_CMD_OFF            = 0,
     //! Turns on, initializes and mutes speaker
-    WPAD_SPEAKER_ON             = 1,
+    WPAD_SPEAKER_CMD_ON             = 1,
     //! Mutes speaker
-    WPAD_SPEAKER_MUTE           = 2,
+    WPAD_SPEAKER_CMD_MUTE           = 2,
     //! Unmutes speaker
-    WPAD_SPEAKER_UNMUTE         = 3,
-    //! Allows audio to play, use after setting WPAD_SPEAKER_ON and before playing sound
-    WPAD_SPEAKER_FINISH_INIT    = 4,
-    //! Does the same as WPAD_SPEAKER_ON
-    WPAD_SPEAKER_ON_ALT         = 5
-} WPADSpeakerMode;
+    WPAD_SPEAKER_CMD_UNMUTE         = 3,
+    //! Allows sound to play
+    WPAD_SPEAKER_CMD_PLAY    = 4,
+    //! Does the same as WPAD_SPEAKER_CMD_ON
+    WPAD_SPEAKER_CMD_ON_ALT         = 5
+} WPADSpeakerCmd;
 
 //! MotionPlus Mode.
 typedef enum WPADMplsMode
@@ -508,13 +509,13 @@ WPADControlLed(WPADChan channel,
 */
 int32_t 
 WPADControlDpd(WPADChan channel,
-               WPADDpdMode mode,
+               WPADDpdFormat mode,
                WPADControlDpdCallback callback);
 
 /**
  * Returns the associated controller's IR mode
  */
-WPADDpdMode
+WPADDpdFormat
 WPADGetDpdFormat(WPADChan chan);
 
 /**
@@ -529,7 +530,7 @@ WPADControlMotor(WPADChan chan,
  */
 int32_t
 WPADControlSpeaker(WPADChan chan,
-                   WPADSpeakerMode mode,
+                   WPADSpeakerCmd mode,
                    WPADControlSpeakerCallback);
 
 /**

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -769,17 +769,18 @@ BOOL
 WPADStartSyncDevice();
 
 /**
- * Starts searching for a WPAD controller in pairing mode that matches specified properties, and syncs with it
- * \param deviceAddress Bluetooth address of the device to connect to. If deviceAddress is 00:00:00:00:00:00, any address is matched
- * \param deviceName up to 24 starting characters of the Bluetooth name of the device to connect to, full name not necessary
+ * Starts attempts to sync with a WPAD with the specified properties,
+ * if unable to do so, starts a normal sync as with WPADStartSyncDevice
+ * \param deviceAddress Bluetooth address of the device to connect to.
+ * \param deviceName Bluetooth name of the device to connect to (up to 24 characters)
  * \return TRUE if sync started
  *
  * Usage:
  * \code
  * WPADAddress addr;
- * memset(&addr, 0, 6);
- * // Will search for controllers with any address and a name that starts with "Nintendo"
- * WPADStartSyncDeviceEx(addr, "Nintendo");
+ * memset(&addr, 0x10, 6);
+ * // Initially searches for device with address 10:10:10:10:10:10 and name "Nintendo"
+ * WPADStartSyncDeviceEx(&addr, "Nintendo");
  * \endcode
  */
 BOOL

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -224,18 +224,18 @@ typedef enum WPADLed
   WPAD_LED_FOUR = 0x8
 } WPADLed;
 
-/** 
- * For more information see <a href="https://wiibrew.org/wiki/Wiimote#Data_Formats">IR Data Formats</a>
- */
-typedef enum WPADDpdMode {
+//!  WPAD Infrared Mode. For more information see <a href="https://wiibrew.org/wiki/Wiimote#Data_Formats">IR Data Formats</a>
+typedef enum WPADDpdMode
+{
     WPAD_DPD_DISABLE = 0,
     WPAD_DPD_ENABLE_BASIC = 1,
     WPAD_DPD_ENABLE_EXTENDED = 3,
     WPAD_DPD_ENABLE_FULL = 5
 } WPADDpdMode;
 
-
-typedef enum WPADPeripheralSpace {
+//! WPAD Peripheral Memory Space Prefixes
+typedef enum WPADPeripheralSpace
+{
     SPEAKER    = 0xA2,
     EXTENSION  = 0xA4,
     MOTIONPLUS = 0xA6,
@@ -360,7 +360,7 @@ WPADIsMplsIntegrated(WPADChan channel);
 
 /**
  * Reads from the device's memory
- * \param destination where the recevied data will be stored
+ * \param destination where the received data will be stored
  * \param size number of bytes to read
  * \param address
  * device memory address, see

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -15,6 +15,7 @@ extern "C" {
 
 typedef struct WPADStatusProController WPADStatusProController;
 typedef struct WPADVec2D WPADVec2D;
+typedef struct WPADInfo WPADInfo;
 typedef struct WPADiQueueElement WPADiQueueElement;
 typedef struct WPADiQueue WPADiQueue;
 
@@ -313,6 +314,30 @@ WUT_CHECK_OFFSET(WPADStatusProController, 0x34, rightStick);
 WUT_CHECK_OFFSET(WPADStatusProController, 0x40, dataFormat);
 WUT_CHECK_SIZE(WPADStatusProController, 0x44);
 
+struct WPADInfo
+{
+    uint32_t irEnabled;
+    uint32_t speakerEnabled;
+    uint32_t extensionAttached;
+    uint32_t batteryLow;
+    uint32_t batteryNearEmpty;
+    uint8_t batteryLevel;
+    uint8_t led;
+    uint8_t protocol;
+    uint8_t firmware;
+};
+WUT_CHECK_OFFSET(WPADInfo, 0x00, irEnabled);
+WUT_CHECK_OFFSET(WPADInfo, 0x04, speakerEnabled);
+WUT_CHECK_OFFSET(WPADInfo, 0x08, extensionAttached);
+WUT_CHECK_OFFSET(WPADInfo, 0x0c, batteryLow);
+WUT_CHECK_OFFSET(WPADInfo, 0x10, batteryNearEmpty);
+WUT_CHECK_OFFSET(WPADInfo, 0x14, batteryLevel);
+WUT_CHECK_OFFSET(WPADInfo, 0x15, led);
+WUT_CHECK_OFFSET(WPADInfo, 0x16, protocol);
+WUT_CHECK_OFFSET(WPADInfo, 0x17, firmware);
+WUT_CHECK_SIZE(WPADInfo, 0x18);
+
+
 struct WPADiQueueElement
 {
     uint8_t data[0x30];
@@ -338,6 +363,7 @@ WUT_CHECK_SIZE(WPADiQueue, 0xc);
 typedef void (*WPADIsMplsAttachedCallback)(WPADChan chan, int32_t status);
 typedef void (*WPADControlLedCallback)(WPADChan chan, int32_t status);
 typedef void (*WPADControlDpdCallback)(WPADChan chan, int32_t status);
+typedef void (*WPADGetInfoCallback)(WPADChan chan, int32_t status);
 
 typedef void (*WPADReadMemoryCallback)(WPADChan chan, int32_t status);
 typedef void (*WPADWriteMemoryCallback)(WPADChan chan, int32_t status);
@@ -417,6 +443,20 @@ WPADIsMplsAttached(WPADChan channel,
  */
 int32_t
 WPADIsMplsIntegrated(WPADChan channel);
+
+/**
+ * Retrieves status info from the controller
+ */
+int32_t
+WPADGetInfo(WPADChan channel,
+            WPADInfo* outInfo);
+/**
+ * Retrieves status info from the controller asynchronously
+ */
+int32_t
+WPADGetInfoAsync(WPADChan channel,
+            WPADInfo* outInfo,
+            WPADGetInfoCallback);
 
 /**
  * Reads from the device's memory

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -528,9 +528,9 @@ WPADControlMotor(WPADChan chan,
  * Sets the wiimote speaker mode
  */
 int32_t
-WPADControlSpeakerMode(WPADChan chan,
-                       WPADSpeakerMode mode,
-                       WPADControlSpeakerCallback);
+WPADControlSpeaker(WPADChan chan,
+                   WPADSpeakerMode mode,
+                   WPADControlSpeakerCallback);
 
 /**
  * Returns whether the wiimote's speaker is enabled
@@ -658,6 +658,7 @@ WPADReadExtReg(WPADChan channel,
  * \sa
  * - WPADWriteMemoryAsync()
  * - WPADReadExtReg()
+ *
  * Usage:
  * \code
  * // Setting speaker volume on specific controller

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -281,17 +281,17 @@ typedef enum WPADDpdFormat
 typedef enum WPADSpeakerCmd
 {
     //! Deinitializes and turns off speaker
-    WPAD_SPEAKER_CMD_OFF            = 0,
-    //! Turns on, initializes and mutes speaker
-    WPAD_SPEAKER_CMD_ON             = 1,
+    WPAD_SPEAKER_CMD_OFF    = 0,
+    //! Turns on and initializes speaker to use 4-bit Yamaha ADPCM data format at 3000 Hz
+    WPAD_SPEAKER_CMD_ON     = 1,
     //! Mutes speaker
-    WPAD_SPEAKER_CMD_MUTE           = 2,
+    WPAD_SPEAKER_CMD_MUTE   = 2,
     //! Unmutes speaker
-    WPAD_SPEAKER_CMD_UNMUTE         = 3,
+    WPAD_SPEAKER_CMD_UNMUTE = 3,
     //! Allows sound to play
-    WPAD_SPEAKER_CMD_PLAY    = 4,
+    WPAD_SPEAKER_CMD_PLAY   = 4,
     //! Does the same as WPAD_SPEAKER_CMD_ON
-    WPAD_SPEAKER_CMD_ON_ALT         = 5
+    WPAD_SPEAKER_CMD_ON_ALT = 5
 } WPADSpeakerCmd;
 
 //! MotionPlus Mode.
@@ -548,6 +548,12 @@ WPADCanSendStreamData(WPADChan chan);
 
 /**
  * Sends data to be played by wiimote speaker
+ * make sure the data is in the format the speaker was initialized for,
+ * (4-bit Yamaha ADPCM by default)
+ * \param data audio encoded in initialized format
+ * \param size number of bytes to send
+ * \returns -2, if not possible to send data at this moment
+ * \returns -1, if chan is invalid, data is null or size is more than 20
  */
 int32_t
 WPADSendStreamData(WPADChan chan,

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -38,6 +38,39 @@ typedef enum WPADChan
 //! Data format.
 typedef enum WPADDataFormat
 {
+   //! Wii Remote buttons
+   WPAD_FMT_CORE                       = 0,
+   //! Wii Remote buttons and accelerometer
+   WPAD_FMT_CORE_ACC                   = 1,
+   //! Wii Remote buttons, accelerometer and IR pos
+   WPAD_FMT_CORE_ACC_DPD               = 2,
+   //! Wii Remote buttons, Nunchuk
+   WPAD_FMT_NUNCHUK                    = 3,
+   //! Wii Remote buttons, accelerometer, Nunchuk
+   WPAD_FMT_NUNCHUK_ACC                = 4,
+   //! Wii Remote buttons, accelerometer, IR pos, Nunchuk
+   WPAD_FMT_NUNCHUK_ACC_DPD            = 5,
+   //! Wii Remote buttons, Classic Controller
+   WPAD_FMT_CLASSIC                    = 6,
+   //! Wii Remote buttons, accelerometer, Classic Controller
+   WPAD_FMT_CLASSIC_ACC                = 7,
+   //! Wii Remote buttons, accelerometer, IR pos, Classic Controller
+   WPAD_FMT_CLASSIC_ACC_DPD            = 8,
+   //! Wii Remote buttons, accelerometer and IR pos with bounds
+   WPAD_FMT_CORE_ACC_DPD_FULL          = 9,
+   //! Wii Remote, Densha De GO! Shinkansen Controller
+   WPAD_FMT_TRAIN                      = 10,
+   //! Guitar Hero Guitar
+   WPAD_FMT_GUITAR                     = 11,
+   //! Wii Balance Board
+   WPAD_FMT_BALANCE_BOARD              = 12,
+   //! Guitar Hero World Tour Drums
+   WPAD_FMT_DRUM                       = 15,
+   //! Wii Remote buttons, accelerometer, IR pos, Motion Plus gyroscope
+   WPAD_FMT_MPLUS                      = 16,
+   //! Wii Remote, Taiko no Testsujin TaTaCon
+   WPAD_FMT_TAIKO                      = 17,
+   //! Wii U Pro Controller
    WPAD_FMT_PRO_CONTROLLER             = 22,
 } WPADDataFormat;
 

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -498,7 +498,7 @@ WPADRead(WPADChan chan,
 /**
 * Controls the associated WPADChan's LEDs
 */
-void
+int32_t
 WPADControlLed(WPADChan channel, 
                WPADLed led, 
                WPADControlLedCallback callback);
@@ -753,14 +753,14 @@ void
 WPADSetAutoSleepTime(uint8_t time);
 
 /**
- * Starts searching for with a WPAD controller in pairing mode and syncs with it
+ * Starts searching for a WPAD controller in pairing mode and syncs with it
  * \return TRUE if sync started
  */
 BOOL
 WPADStartSyncDevice();
 
 /**
- * Starts searching for with a WPAD controller in pairing mode and syncs with it
+ * Starts searching for a WPAD controller in pairing mode that matches specified properties, and syncs with it
  * \param deviceAddress Bluetooth address of the device to connect to. If deviceAddress is 00:00:00:00:00:00, any address is matched
  * \param deviceName up to 24 starting characters of the Bluetooth name of the device to connect to, full name not necessary
  * \return TRUE if sync started
@@ -816,7 +816,7 @@ WPADiIsAvailableCmdQueue(WPADiQueue* queue,
  * Parses incoming HID report data for a controller
  * \return -1 if first byte is outside the valid input report range (0x20 to 0x3f)
  */
-uint32_t
+int32_t
 WPADiHIDParser(WPADChan channel,
                uint8_t* hidData);
 

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -629,6 +629,19 @@ WPADGetBLCalibration(WPADChan channel,
                      uint32_t address,
                      uint32_t size,
                      WPADReadMemoryCallback callback);
+/**
+ * Sets power save mode, this makes the controller only report input data
+ * when it changes
+ */
+void
+WPADSetPowerSaveMode(WPADChan chan,
+                     BOOL powerSave);
+
+/**
+ * \return FALSE, if power save mode is off
+ */
+BOOL
+WPADGetPowerSaveMode(WPADChan chan);
 
 /**
  * Retrieves the bluetooth address of the controller
@@ -767,7 +780,7 @@ WPADiSendSetPort(WPADiQueue* cmdQueue,
 BOOL
 WPADiSendSetReportType(WPADiQueue* cmdQueue,
                        WPADDataFormat dataFormat,
-                       BOOL noRepeat,
+                       BOOL powerSave,
                        WPADiSendCallback callback);
 
 /**

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -343,13 +343,20 @@ WPADControlMotor(WPADChan chan,
                  BOOL motorEnabled);
 
 /**
- * Returns whether the WPADChan has MotionPlus
+ * Gets whether MotionPlus is enabled for the WPAD
+ * \param enabled is set if MotionPlus is enabled
  */
 int32_t 
 WPADIsMplsAttached(WPADChan channel, 
-                  BOOL *attachedOut, 
+                  BOOL *enabled,
                   WPADIsMplsAttachedCallback callback);
 
+/**
+ * Returns whether the WPADChan has MotionPlus integrated
+ * \return -1 if controller is not connected, 1 if MotionPlus integrated, 0 if not
+ */
+int32_t
+WPADIsMplsIntegrated(WPADChan channel);
 
 /**
  * Reads from the device's memory

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -270,6 +270,16 @@ typedef enum WPADDpdMode
     WPAD_DPD_ENABLE_FULL = 5
 } WPADDpdMode;
 
+//! WPAD Speaker Mode.
+typedef enum WPADSpeakerMode
+{
+    OFF = 0,
+    ON = 1,
+    MUTE = 2,
+    UNMUTE = 3
+} WPADSpeakerMode;
+
+
 //! WPAD Peripheral Memory Space Prefixes
 typedef enum WPADPeripheralSpace
 {
@@ -363,6 +373,7 @@ WUT_CHECK_SIZE(WPADiQueue, 0xc);
 typedef void (*WPADIsMplsAttachedCallback)(WPADChan chan, int32_t status);
 typedef void (*WPADControlLedCallback)(WPADChan chan, int32_t status);
 typedef void (*WPADControlDpdCallback)(WPADChan chan, int32_t status);
+typedef void (*WPADControlSpeakerCallback)(WPADChan chan, int32_t status);
 typedef void (*WPADGetInfoCallback)(WPADChan chan, int32_t status);
 
 typedef void (*WPADReadMemoryCallback)(WPADChan chan, int32_t status);
@@ -426,6 +437,34 @@ WPADControlDpd(WPADChan channel,
 void
 WPADControlMotor(WPADChan chan,
                  BOOL motorEnabled);
+
+/**
+ * Sets the wiimote speaker mode
+ */
+int32_t
+WPADControlSpeakerMode(WPADChan chan,
+                       WPADSpeakerMode mode,
+                       WPADControlSpeakerCallback);
+
+/**
+ * Returns whether the wiimote's speaker is enabled
+ */
+BOOL
+WPADIsSpeakerEnabled(WPADChan chan);
+
+/**
+ * Returns whether it is possible to send data to the wiimote's speaker
+ */
+BOOL
+WPADCanSendStreamData(WPADChan chan);
+
+/**
+ * Sends data to be played by wiimote speaker
+ */
+int32_t
+WPADSendStreamData(WPADChan chan,
+                   void* data,
+                   uint32_t size);
 
 /**
  * Gets whether MotionPlus is enabled for the WPAD
@@ -666,6 +705,7 @@ WPADiSendMuteSpeaker(WPADiQueue* cmdQueue,
 
 /**
  * Queues HID Report for sending speaker stream data
+ * used internally by \ref WPADSendStreamData
  */
 BOOL
 WPADiSendStreamData(WPADiQueue* cmdQueue,

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -96,7 +96,9 @@ typedef enum WPADExtensionType
    //! Pro Controller.
    WPAD_EXT_PRO_CONTROLLER          = 31,
    //! No controller found.
-   WPAD_EXT_DEV_NOT_FOUND           = 253
+   WPAD_EXT_DEV_NOT_FOUND           = 253,
+   //! Extension unknown.
+   WPAD_EXT_UNKNOWN                 = 255
 } WPADExtensionType;
 
 //! Wii Remote buttons.
@@ -406,6 +408,12 @@ typedef void (*WPADWriteMemoryCallback)(WPADChan chan, int32_t status);
 
 typedef void (*WPADSamplingCallback)(WPADChan chan);
 typedef void (*WPADExtensionCallback)(WPADChan chan, int32_t status);
+typedef void (*WPADExtensionCallback)(WPADChan chan, WPADExtensionType ext);
+
+/**
+ * Callback called when a controller connects or disconnects
+ * \param status 0 on connect, -1 on disconnect
+ */
 typedef void (*WPADConnectCallback)(WPADChan chan, int32_t status);
 
 typedef void (*WPADiSendCallback)(WPADChan chan, int32_t status);
@@ -455,6 +463,12 @@ int32_t
 WPADControlDpd(WPADChan channel,
                WPADDpdMode mode,
                WPADControlDpdCallback callback);
+
+/**
+ * Returns the associated controller's IR mode
+ */
+WPADDpdMode
+WPADGetDpdFormat(WPADChan chan);
 
 /**
  * Controls the associated WPADChan's rumble motor.

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -388,9 +388,9 @@ WUT_CHECK_SIZE(WPADiQueue, 0xc);
 
 struct WPADAddress
 {
-    uint8_t btMacAddress[6];
+    uint8_t btDeviceAddress[6];
 };
-WUT_CHECK_OFFSET(WPADAddress, 0x00, btMacAddress);
+WUT_CHECK_OFFSET(WPADAddress, 0x00, btDeviceAddress);
 WUT_CHECK_SIZE(WPADAddress, 0x6);
 
 typedef void (*WPADIsMplsAttachedCallback)(WPADChan chan, int32_t status);
@@ -663,7 +663,34 @@ WPADEnableWiiRemote(BOOL enable);
 void
 WPADSetAutoSleepTime(uint8_t time);
 
+/**
+ * Starts searching for with a WPAD controller in pairing mode and syncs with it
+ * \return TRUE if sync started
+ */
+BOOL
+WPADStartSyncDevice();
 
+/**
+ * Starts searching for with a WPAD controller in pairing mode and syncs with it
+ * \param deviceAddress Bluetooth address of the device to connect to. If deviceAddress is 00:00:00:00:00:00, any address is matched
+ * \param deviceName up to 24 starting characters of the Bluetooth name of the device to connect to, full name not necessary
+ * \return TRUE if sync started
+ *
+ * Usage:
+ * \code
+ * WPADAddress addr;
+ * memset(&addr, 0, 6);
+ * WPADStartSyncDevice(addr, "Nintendo");
+ * \endcode
+ */
+BOOL
+WPADStartSyncDeviceEx(WPADAddress* deviceAddress,
+                      const char* deviceName);
+
+/**
+ * Set function to be run upon controller connect/disconnect
+ * status is set to 0
+ */
 WPADConnectCallback
 WPADSetConnectCallback(WPADChan chan,
                        WPADConnectCallback callback);

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -386,6 +386,13 @@ WUT_CHECK_OFFSET(WPADiQueue, 0x04, elements);
 WUT_CHECK_OFFSET(WPADiQueue, 0x08, capacity);
 WUT_CHECK_SIZE(WPADiQueue, 0xc);
 
+struct WPADAddress
+{
+    uint8_t btMacAddress[6];
+};
+WUT_CHECK_OFFSET(WPADAddress, 0x00, btMacAddress);
+WUT_CHECK_SIZE(WPADAddress, 0x6);
+
 typedef void (*WPADIsMplsAttachedCallback)(WPADChan chan, int32_t status);
 typedef void (*WPADControlLedCallback)(WPADChan chan, int32_t status);
 typedef void (*WPADControlDpdCallback)(WPADChan chan, int32_t status);
@@ -606,6 +613,13 @@ WPADGetBLCalibration(WPADChan channel,
                      uint32_t address,
                      uint32_t size,
                      WPADReadMemoryCallback callback);
+
+/**
+ * Retrieves the bluetooth address of the controller
+ */
+void
+WPADGetAddress(WPADChan chan,
+               WPADAddress* outAddress);
 
 /**
  * Enables/disables motors globally

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -279,6 +279,13 @@ typedef enum WPADSpeakerMode
     WPAD_SPEAKER_UNMUTE = 3
 } WPADSpeakerMode;
 
+//! MotionPlus Mode.
+typedef enum WPADMplsMode
+{
+    WPAD_MPLS_MODE_DISABLE  = 0,
+    WPAD_MPLS_MODE_ENABLE   = 4,
+} WPADMplsMode;
+
 
 //! WPAD Peripheral Memory Space Prefixes
 typedef enum WPADPeripheralSpace
@@ -800,6 +807,14 @@ WPADiReadGameData(WPADChan channel,
                   uint16_t size,
                   uint32_t offset,
                   WPADReadMemoryCallback callback);
+
+/**
+ * Get MotionPlus mode
+ *
+ * identical to \ref KPADGetMplsStatus
+ */
+WPADMplsMode
+WPADiGetMplsStatus();
 
 #ifdef __cplusplus
 }

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -235,7 +235,7 @@ typedef enum WPADDpdMode {
 } WPADDpdMode;
 
 
-typedef enum WPADPeripheral {
+typedef enum WPADPeripheralSpace {
     SPEAKER    = 0xA2,
     EXTENSION  = 0xA4,
     MOTIONPLUS = 0xA6,


### PR DESCRIPTION
Adds:
 - `WPADLed`
 - `WPADDpdMode`
 - `WPADPeripheral`
 - `WPADIsMplsAttached()`
 - `WPADGetDataFormat()`
 - `WPADControlLed()`
 - `WPADControlDpd()`
 - `WPADReadMemoryAsync()`
 - `WPADWriteMemoryAsync()`
 - `WPADReadExtReg()`
 - `WPADWriteExtReg()`
 - `WPADGetBLCalibration()`
 - `KPADEnableMpls()`
 - `KPADDisableMpls()`
 - and more