### PR TITLE
coreinit: add stopwatch.h and stopwatchatomic.h

### DIFF
--- a/include/coreinit/stopwatch.h
+++ b/include/coreinit/stopwatch.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <wut.h>
+#include "spinlock.h"
+#include "time.h"
+
+/**
+ * \defgroup coreinit_stopwatch Lock-based Stopwatch
+ * \ingroup coreinit
+ *
+ * @{
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct OSStopwatch OSStopwatch;
+
+struct OSStopwatch {
+    //! Lock
+    OSSpinLock lock;
+    //! Tag
+    char* name;
+    //! Number of times the stopwatch has been stopped
+    uint32_t hitCount;
+    //! Total time from first start to last stop
+    OSTime totalTime;
+    //! Minimum time between stops
+    OSTime minTime;
+    //! Maximum time between stops
+    OSTime maxTime;
+    //! Last time the watch was started
+    OSTime startTime;
+    //! Whether the stopwatch is running
+    BOOL running;
+    WUT_PADDING_BYTES(0x4);
+};
+WUT_CHECK_OFFSET(OSStopwatch, 0x00, lock);
+WUT_CHECK_OFFSET(OSStopwatch, 0x10, name);
+WUT_CHECK_OFFSET(OSStopwatch, 0x14, hitCount);
+WUT_CHECK_OFFSET(OSStopwatch, 0x18, totalTime);
+WUT_CHECK_OFFSET(OSStopwatch, 0x20, minTime);
+WUT_CHECK_OFFSET(OSStopwatch, 0x28, maxTime);
+WUT_CHECK_OFFSET(OSStopwatch, 0x30, startTime);
+WUT_CHECK_OFFSET(OSStopwatch, 0x38, running);
+WUT_CHECK_SIZE(OSStopwatch, 0x40);
+
+/**
+ * Initialises the stopwatch,
+ * stopwatches must be initialized before any other stopwatch functions are used
+ */
+void
+OSInitStopwatch(OSStopwatch *stopwatch,
+                const char* name);
+
+/**
+ *  Resets all stopwatch data
+ */
+void
+OSResetStopWatch(OSStopwatch *stopwatch);
+
+/**
+ * Starts the stopwatch.
+ * if already started, will update the start time without resetting the total time
+ */
+void
+OSStartStopwatch(OSStopwatch *stopwatch);
+
+/**
+ * Stops the stopwatch and increments hit count.
+ * Nothing happens if the stopwatch has already been stopped
+ */
+void
+OSStopStopwatch(OSStopwatch *stopwatch);
+
+/**
+ * Returns the total time the stopwatch has been running
+ */
+OSTime
+OSCheckStopwatch(OSStopwatch *stopwatch);
+
+/**
+ *  Dumps stopwatch info to the Cafe OS warn log
+ */
+void
+OSDumpStopwatch(OSStopwatch *stopwatch);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/include/coreinit/stopwatch.h
+++ b/include/coreinit/stopwatch.h
@@ -58,7 +58,7 @@ OSInitStopwatch(OSStopwatch *stopwatch,
  *  Resets all stopwatch data
  */
 void
-OSResetStopWatch(OSStopwatch *stopwatch);
+OSResetStopwatch(OSStopwatch *stopwatch);
 
 /**
  * Starts the stopwatch.

--- a/include/coreinit/stopwatch.h
+++ b/include/coreinit/stopwatch.h
@@ -16,24 +16,25 @@ extern "C" {
 
 typedef struct OSStopwatch OSStopwatch;
 
-struct OSStopwatch {
-    //! Lock
-    OSSpinLock lock;
-    //! Tag
-    char* name;
-    //! Number of times the stopwatch has been stopped
-    uint32_t hitCount;
-    //! Total time from first start to last stop
-    OSTime totalTime;
-    //! Minimum time between stops
-    OSTime minTime;
-    //! Maximum time between stops
-    OSTime maxTime;
-    //! Last time the watch was started
-    OSTime startTime;
-    //! Whether the stopwatch is running
-    BOOL running;
-    WUT_PADDING_BYTES(0x4);
+struct OSStopwatch
+{
+   //! Lock
+   OSSpinLock lock;
+   //! Tag
+   const char *name;
+   //! Number of times the stopwatch has been stopped
+   uint32_t hitCount;
+   //! Total time from first start to last stop
+   OSTime totalTime;
+   //! Minimum time between stops
+   OSTime minTime;
+   //! Maximum time between stops
+   OSTime maxTime;
+   //! Last time the watch was started
+   OSTime startTime;
+   //! Whether the stopwatch is running
+   BOOL running;
+   WUT_PADDING_BYTES(0x4);
 };
 WUT_CHECK_OFFSET(OSStopwatch, 0x00, lock);
 WUT_CHECK_OFFSET(OSStopwatch, 0x10, name);
@@ -51,7 +52,7 @@ WUT_CHECK_SIZE(OSStopwatch, 0x40);
  */
 void
 OSInitStopwatch(OSStopwatch *stopwatch,
-                const char* name);
+                const char *name);
 
 /**
  *  Resets all stopwatch data

--- a/include/coreinit/stopwatchatomic.h
+++ b/include/coreinit/stopwatchatomic.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <wut.h>
+#include "time.h"
+
+/**
+ * \defgroup coreinit_stopwatchatomic Atomic Stopwatch
+ * \ingroup coreinit
+ *
+ * @{
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct OSStopWatchAtomic OSStopWatchAtomic;
+
+struct OSStopWatchAtomic {
+    //! Last time the watch was started
+    OSTime startTime;
+    //! Total time from first start to last stop
+    OSTime totalTime;
+};
+WUT_CHECK_OFFSET(OSStopWatchAtomic, 0x00, startTime);
+WUT_CHECK_OFFSET(OSStopWatchAtomic, 0x08, totalTime);
+WUT_CHECK_SIZE(OSStopWatchAtomic, 0x10);
+
+/**
+ * Start the stopwatch.
+ * Only updates the start time
+ * \returns total time on stopwatch
+ */
+OSTime
+OSStopWatchStart(OSStopWatchAtomic *stopWatch);
+
+/**
+ * Stop the stopwatch.
+ * Resets the start time to 0
+ * \returns total time on stopwatch
+ */
+OSTime
+OSStopWatchStop(OSStopWatchAtomic *stopWatch);
+
+/**
+ * Get the current time on the stopwatch
+ * \returns current time on stopwatch
+ */
+OSTime OSStopWatchLap(OSStopWatchAtomic *stopWatch);
+
+
+/**
+ * Stops and resets the stop watch.
+ * Clears start and total time
+ * \returns previous total time
+ */
+OSTime
+OSStopWatchReset(OSStopWatchAtomic *stopWatch);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/include/coreinit/stopwatchatomic.h
+++ b/include/coreinit/stopwatchatomic.h
@@ -15,11 +15,12 @@ extern "C" {
 
 typedef struct OSStopWatchAtomic OSStopWatchAtomic;
 
-struct OSStopWatchAtomic {
-    //! Last time the watch was started
-    OSTime startTime;
-    //! Total time from first start to last stop
-    OSTime totalTime;
+struct OSStopWatchAtomic
+{
+   //! Last time the watch was started
+   OSTime startTime;
+   //! Total time from first start to last stop
+   OSTime totalTime;
 };
 WUT_CHECK_OFFSET(OSStopWatchAtomic, 0x00, startTime);
 WUT_CHECK_OFFSET(OSStopWatchAtomic, 0x08, totalTime);
@@ -45,7 +46,8 @@ OSStopWatchStop(OSStopWatchAtomic *stopWatch);
  * Get the current time on the stopwatch
  * \returns current time on stopwatch
  */
-OSTime OSStopWatchLap(OSStopWatchAtomic *stopWatch);
+OSTime
+OSStopWatchLap(OSStopWatchAtomic *stopWatch);
 
 
 /**

--- a/tests/test_compile_headers_common/test_compile_headers_list.h
+++ b/tests/test_compile_headers_common/test_compile_headers_list.h
@@ -50,6 +50,8 @@
 #include <coreinit/semaphore.h>
 #include <coreinit/smd.h>
 #include <coreinit/spinlock.h>
+#include <coreinit/stopwatch.h>
+#include <coreinit/stopwatchatomic.h>
 #include <coreinit/systeminfo.h>
 #include <coreinit/taskqueue.h>
 #include <coreinit/thread.h>


### PR DESCRIPTION
Adds the stopwatch functions and structs.
Named what should be `OSStopWatch` to `OSStopWatchAtomic` to avoid confusion with `OSStopwatch`