### PR TITLE
gx2: Add GX2AllocateTilingApertureEx and GX2FreeTilingAperture

### DIFF
--- a/include/gx2/aperture.h
+++ b/include/gx2/aperture.h
@@ -1,0 +1,62 @@
+#pragma once
+#include <wut.h>
+#include "enum.h"
+#include "surface.h"
+
+/**
+ * \defgroup gx2_aperture Aperture
+ * \ingroup gx2
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint32_t GX2ApertureHandle;
+
+/**
+ * Allocates a tiling aperture.
+ * This function creates a linear and untiled buffer to read from and write to the surface.
+ * The total size of the buffer will be width * height * bpp.
+ * 
+ * \param surface
+ * A pointer to the surface to create the tiling aperture for.
+ * 
+ * \param level
+ * The level of the surface to create the tiling aperture for.
+ *
+ * \param depth
+ * The depth of the surface to create the tiling aperture for.
+ * 
+ * \param endian
+ * The endian swap mode.
+ * 
+ * \param outHandle
+ * A pointer to store the handle for the aperture.
+ * 
+ * \param outAddress
+ * A pointer to store the address for the aperture.
+ */
+void
+GX2AllocateTilingApertureEx(GX2Surface *surface,
+                            uint32_t level,
+                            uint32_t depth,
+                            GX2EndianSwapMode endian,
+                            GX2ApertureHandle *outHandle,
+                            void **outAddress);
+
+/**
+ * Frees an allocated tiling aperture.
+ *
+ * \param handle
+ * The handle of the tiling aperture which should be freed.
+ */
+void
+GX2FreeTilingAperture(GX2ApertureHandle handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/tests/test_compile_headers_common/test_compile_headers_list.h
+++ b/tests/test_compile_headers_common/test_compile_headers_list.h
@@ -60,6 +60,7 @@
 #include <coreinit/userconfig.h>
 #include <dmae/mem.h>
 #include <dmae/sync.h>
+#include <gx2/aperture.h>
 #include <gx2/clear.h>
 #include <gx2/context.h>
 #include <gx2/debug.h>


### PR DESCRIPTION
Based on [decaf-emu](https://github.com/decaf-emu/decaf-emu/blob/1062c0492ba55d980356d34c23145bb3e9f28cce/src/libdecaf/src/cafe/libraries/gx2/gx2_aperture.h) with added documentation.