### PR TITLE
More DRX definitions

### DIFF
--- a/include/nsysccr/cdc.h
+++ b/include/nsysccr/cdc.h
@@ -136,13 +136,14 @@ typedef enum CCRCDCExt
 
 typedef enum CCRCDCDrhStateEnum
 {
-   CCR_CDC_SYS_DRH_STATE_UNK0   = 0x00,
-   CCR_CDC_SYS_DRH_STATE_UNK1   = 0x01,
-   CCR_CDC_SYS_DRH_STATE_UNK2   = 0x02,
-   CCR_CDC_SYS_DRH_STATE_UNK3   = 0x03,
-   CCR_CDC_SYS_DRH_STATE_ECO    = 0x04,
-   CCR_CDC_SYS_DRH_STATE_UNK7F  = 0x7F,
-   CCR_CDC_SYS_DRH_STATE_CAFE   = 0xFF,
+   CCR_CDC_SYS_DRH_STATE_NORADIO = 0x00,
+   CCR_CDC_SYS_DRH_STATE_WII     = 0x01,
+   CCR_CDC_SYS_DRH_STATE_UNK2    = 0x02,
+   CCR_CDC_SYS_DRH_STATE_NODRC   = 0x03,
+   CCR_CDC_SYS_DRH_STATE_ECO     = 0x04,
+   //! On latest firmware this state is not recognized
+   CCR_CDC_SYS_DRH_STATE_UNK7F   = 0x7F,
+   CCR_CDC_SYS_DRH_STATE_CAFE    = 0xFF,
 } CCRCDCDrhStateEnum;
 
 struct WUT_PACKED CCRCDCMacAddress
@@ -185,9 +186,10 @@ WUT_CHECK_SIZE(CCRCDCSysMessage, 0x4);
 struct WUT_PACKED CCRCDCEepromData
 {
    uint32_t version;
-   WUT_UNKNOWN_BYTES(0x300);
+   uint8_t data[0x300];
 };
 WUT_CHECK_OFFSET(CCRCDCEepromData, 0x0, version);
+WUT_CHECK_OFFSET(CCRCDCEepromData, 0x4, data);
 WUT_CHECK_SIZE(CCRCDCEepromData, 0x304);
 
 struct WUT_PACKED CCRCDCWowlWakeDrcArg

--- a/include/nsysccr/cdc.h
+++ b/include/nsysccr/cdc.h
@@ -141,7 +141,6 @@ typedef enum CCRCDCDrhStateEnum
    CCR_CDC_SYS_DRH_STATE_UNK2    = 0x02,
    CCR_CDC_SYS_DRH_STATE_NODRC   = 0x03,
    CCR_CDC_SYS_DRH_STATE_ECO     = 0x04,
-   //! On latest firmware this state is not recognized
    CCR_CDC_SYS_DRH_STATE_UNK7F   = 0x7F,
    CCR_CDC_SYS_DRH_STATE_CAFE    = 0xFF,
 } CCRCDCDrhStateEnum;


### PR DESCRIPTION
Changed DRH state names, notably:
UNK0-> NORADIO (connected DRCs warn about poor connection and disconnect afterwards)
UNK1-> WII (connected DRCs enter wii mode without input)
UNK2-> [not renamed] (connected DRCs power off and when powered back on, enter wii mode)
UNK3-> NODRC (connected DRCs immediately power off; this mode can only be disabled by rebooting)
UNK7F-> [not renamed] ~~(this mode is not recognized on latest DRH firmware, comment added)~~

DRC EEPROM now defined as data instead of being unknown.
More info yet to be added. What I can say is that the DRC does not know its' own serial.
Initial dumps seem to show that the size is 5E0h bytes total with a filler hex-string of "DEADBABE" at the end (when dumping as DRC0 - dumping as DRC1 shows strange results)