### PR TITLE
nn_acp: Add various save related functions

### DIFF
--- a/cafe/nn_acp.def
+++ b/cafe/nn_acp.def
@@ -77,7 +77,6 @@ ACPGetTitleMetaXmlByTitleListType
 ACPGetTitleSaveDir
 ACPGetTitleSaveDirEx
 ACPGetTitleSaveDirExWithoutMetaCheck
-ACPGetTitleSaveMetaXml
 ACPGetWoodTin
 ACPImportSaveDataFromBuffer
 ACPImportSaveDirOfAccountWithEncryption
@@ -161,3 +160,4 @@ WaitExternalStorage__Q2_2nn3acpFv
 
 :TEXT_WRAP
 ACPGetTitleMetaXml
+ACPGetTitleSaveMetaXml

--- a/include/coreinit/mcp.h
+++ b/include/coreinit/mcp.h
@@ -63,9 +63,11 @@ typedef enum MCPAppType
 
 typedef enum MCPDeviceType
 {
+   MCP_DEVICE_TYPE_AUTO                = 1, /* returns result for ODD, MLC and USB */
    MCP_DEVICE_TYPE_ODD                 = 2,
    MCP_DEVICE_TYPE_MLC                 = 3,
    MCP_DEVICE_TYPE_USB                 = 4,
+   /* any value >= 5 is MCP_DEVICE_TYPE_AUTO */
 } MCPDeviceType;
 
 typedef enum MCPDeviceFlags
@@ -310,7 +312,7 @@ MCP_TitleListByUniqueId(int32_t handle,
 
 MCPError
 MCP_TitleListByDevice(int32_t handle,
-                      const char *device,
+                      const char *deviceName,
                       uint32_t *outTitleCount,
                       MCPTitleListType *titleList,
                       uint32_t titleListSizeBytes);
@@ -324,7 +326,7 @@ MCP_TitleListByDeviceType(int32_t handle,
 MCPError
 MCP_TitleListByAppAndDevice(int32_t handle,
                             MCPAppType appType,
-                            const char *device,
+                            const char *deviceName,
                             uint32_t *outTitleCount,
                             MCPTitleListType *titleList,
                             uint32_t titleListSizeBytes);
@@ -379,6 +381,21 @@ MCP_ChangeEcoSettings(int32_t handle,
                       uint32_t enable,
                       uint32_t maxOnTime,
                       uint16_t defaultOffTime);
+
+static inline const char*
+MCP_GetDeviceNameByDeviceType(MCPDeviceType deviceType) {
+   switch (deviceType) {
+      case MCP_DEVICE_TYPE_AUTO:
+         return "auto";
+      case MCP_DEVICE_TYPE_ODD:
+         return "odd";
+      case MCP_DEVICE_TYPE_MLC:
+         return "mlc";
+      case MCP_DEVICE_TYPE_USB:
+         return "usb";
+   }
+   return "auto";
+}
 
 #ifdef __cplusplus
 }

--- a/include/nn/acp/device.h
+++ b/include/nn/acp/device.h
@@ -12,7 +12,14 @@
 extern "C" {
 #endif
 
-typedef int32_t ACPDeviceType;
+typedef enum ACPDeviceType {
+    ACP_DEVICE_TYPE_AUTO      = 1,
+    ACP_DEVICE_TYPE_ODD       = 2,
+    ACP_DEVICE_TYPE_HFIODISC  = 2, /* when ApplicationDevice is emulated */
+    ACP_DEVICE_TYPE_MLC       = 3,
+    ACP_DEVICE_TYPE_HFIOMLC   = 3, /* when ApplicationDevice is emulated */
+    ACP_DEVICE_TYPE_USB       = 4,
+} ACPDeviceType;
 
 ACPResult
 ACPCheckApplicationDeviceEmulation(BOOL* emulation);

--- a/include/nn/acp/save.h
+++ b/include/nn/acp/save.h
@@ -15,12 +15,26 @@
 extern "C" {
 #endif
 
+typedef uint64_t ACPTitleId;
+typedef struct ACPSaveDirInfo ACPSaveDirInfo;
+
+struct WUT_PACKED ACPSaveDirInfo {
+    WUT_UNKNOWN_BYTES(0x8);
+    uint32_t persistentId;
+    WUT_UNKNOWN_BYTES(0x14);
+    char path[0x40];
+    WUT_PADDING_BYTES(0x80 - 0x60);
+};
+WUT_CHECK_OFFSET(ACPSaveDirInfo, 0x08, persistentId);
+WUT_CHECK_OFFSET(ACPSaveDirInfo, 0x20, path);
+WUT_CHECK_SIZE(ACPSaveDirInfo,0x80);
+
 ACPResult
 ACPCreateSaveDir(uint32_t persistentId,
                  ACPDeviceType deviceType);
 
 ACPResult
-ACPIsExternalStorageRequired(BOOL* required);
+ACPIsExternalStorageRequired(BOOL *required);
 
 ACPResult
 ACPMountExternalStorage();
@@ -78,6 +92,59 @@ ACPUnmountExternalStorage();
 
 ACPResult
 ACPUnmountSaveDir();
+
+/**
+ * Gets all titles id which have save data
+ *
+ * @param deviceType
+ * @param titlesOut needs to be aligned to 0x40
+ * @param maxCount needs to be a multiple of 8
+ * @param countOut
+ * @return ACP_RESULT_SUCCESS on success.
+ */
+ACPResult
+ACPGetSaveDataTitleIdList(ACPDeviceType deviceType,
+                          uint64_t *titlesOut,
+                          uint32_t maxCount,
+                          uint32_t *countOut);
+
+/**
+ * Gets a list of all saves dir for a given title id
+ *
+ * @param titleId
+ * @param deviceType
+ * @param u1 seems to be always 0
+ * @param saveDirInfo needs to be aligned to 0x40
+ * @param maxCount
+ * @param countOut
+ * @return ACP_RESULT_SUCCESS on success.
+ */
+ACPResult
+ACPGetTitleSaveDirEx(uint64_t titleId,
+                     ACPDeviceType deviceType,
+                     uint32_t u1,
+                     ACPSaveDirInfo *saveDirInfo,
+                     uint32_t maxCount,
+                     uint32_t *countOut);
+
+/**
+ * Gets a list of all saves dir for a given title id
+ *
+ * @param titleId
+ * @param deviceType
+ * @param u1 seems to be always 0
+ * @param saveDirInfo needs to be aligned to 0x40
+ * @param maxCount
+ * @param countOut
+ * @return ACP_RESULT_SUCCESS on success.
+ */
+ACPResult
+ACPGetTitleSaveDirExWithoutMetaCheck(uint64_t titleId,
+                                     ACPDeviceType deviceType,
+                                     uint32_t u1,
+                                     ACPSaveDirInfo *saveDirInfo,
+                                     uint32_t maxCount,
+                                     uint32_t *countOut);
 
 #ifdef __cplusplus
 }

--- a/include/nn/acp/title.h
+++ b/include/nn/acp/title.h
@@ -270,6 +270,29 @@ ACPGetTitleMetaXml(ACPTitleId titleId,
 }
 
 ACPResult
+RPLWRAP(ACPGetTitleSaveMetaXml)(uint64_t titleId,
+                                ACPMetaXml* metaXml,
+                                ACPDeviceType deviceType);
+
+/**
+ * Gets the save dir MetaXML for a given title id
+ * @param titleId
+ * @param metaXml must be aligned to 0x40
+ * @param deviceType
+ * @return ACP_RESULT_SUCCESS on success,
+ *         ACP_RESULT_INVALID_PARAMETER if metaXml is not aligned properly
+ */
+static inline ACPResult
+ACPGetTitleSaveMetaXml(ACPTitleId titleId,
+                       ACPMetaXml *metaXml,
+                       ACPDeviceType deviceType) {
+   if ((uintptr_t) metaXml & 0x3F) {
+      return ACP_RESULT_INVALID_PARAMETER;
+   }
+   return RPLWRAP(ACPGetTitleSaveMetaXml)(titleId, metaXml, deviceType);
+}
+
+ACPResult
 ACPGetTitleMetaDir(ACPTitleId titleId,
                    char *directory,
                    size_t directoryLen);


### PR DESCRIPTION
ACPDeviceType values are based on a function in nn_acp.rpl which converts them to be used in `MCP_GetTitleInfoByTitleAndDevice` . 

![grafik | width=100 ](https://github.com/user-attachments/assets/5c6002be-0232-42c8-99b3-b4bb35ffd9b4 )

MCPDeviceType matches the values as well <https://github.com/devkitPro/wut/blob/9a32ef1b658451e1bba97a18edb1c583eecf6cd1/include/coreinit/mcp.h#L64-L69>
