### PR TITLE
camera: event argument correction

### DIFF
--- a/include/camera/camera.h
+++ b/include/camera/camera.h
@@ -73,8 +73,8 @@ struct CAMEventData
    {
       struct
       {
-         //! The surface that finished decoding
-         CAMSurface* surface;
+         //! Pointer to the buffer of the decoded image
+         void* surfaceBuffer;
          //! Handle of instance
          CAMHandle handle;
          //! TRUE if decode failed

--- a/include/camera/camera.h
+++ b/include/camera/camera.h
@@ -92,7 +92,7 @@ struct CAMEventData
    };
 };
 WUT_CHECK_OFFSET(CAMEventData, 0x00, eventType);
-WUT_CHECK_OFFSET(CAMEventData, 0x04, decode.surface);
+WUT_CHECK_OFFSET(CAMEventData, 0x04, decode.surfaceBuffer);
 WUT_CHECK_OFFSET(CAMEventData, 0x08, decode.handle);
 WUT_CHECK_OFFSET(CAMEventData, 0x0c, decode.failed);
 WUT_CHECK_OFFSET(CAMEventData, 0x04, detach.connected);


### PR DESCRIPTION
It was meant to be the surface's buffer, rather than a pointer to the surface that is returned