### PR TITLE
Fix typo in nsysnet and add more `nn::ac` functions.

### DIFF
--- a/include/nn/ac/ac_cpp.h
+++ b/include/nn/ac/ac_cpp.h
@@ -25,7 +25,7 @@ namespace ac
  * An ID number representing a network configuration. These are the same IDs as
  * shown in System Settings' Connection List.
  */
-typedef uint32_t ConfigIdNum;
+using ConfigIdNum = uint32_t;
 
 /**
  * The configuration for a given network profile.
@@ -33,10 +33,12 @@ typedef uint32_t ConfigIdNum;
  */
 using Config = NetConfCfg;
 
+using ErrorCode = uint32_t;
+
 enum Status {
     STATUS_FAILED     = -1,
-    STATUS_OK         = 0,
-    STATUS_PROCESSING = 1,
+    STATUS_OK         =  0,
+    STATUS_PROCESSING =  1,
 };
 
 /**
@@ -49,6 +51,8 @@ namespace detail
 extern "C"
 {
 
+nn::Result BeginLocalConnection__Q2_2nn2acFb(bool unknown);
+void       ClearConfig__Q2_2nn2acFP16netconf_profile_(Config *cfg);
 nn::Result Close__Q2_2nn2acFv();
 nn::Result CloseAll__Q2_2nn2acFv();
 nn::Result Connect__Q2_2nn2acFPC16netconf_profile_(const Config *cfg);
@@ -57,19 +61,33 @@ nn::Result Connect__Q2_2nn2acFv();
 nn::Result ConnectAsync__Q2_2nn2acFPC16netconf_profile_(const Config *cfg);
 nn::Result ConnectAsync__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
 nn::Result ConnectAsync__Q2_2nn2acFv();
+nn::Result ConnectWithRetry__Q2_2nn2acFv();
+nn::Result DeleteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
+nn::Result EndLocalConnection__Q2_2nn2acFv();
 void       Finalize__Q2_2nn2acFv();
 nn::Result GetAssignedAddress__Q2_2nn2acFPUl(uint32_t *ip);
-nn::Result GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status();
+nn::Result GetAssignedAlternativeDns__Q2_2nn2acFPUl(uint32_t *ip);
+nn::Result GetAssignedGateway__Q2_2nn2acFPUl(uint32_t *ip);
+nn::Result GetAssignedPreferedDns__Q2_2nn2acFPUl(uint32_t *ip);
+nn::Result GetAssignedSubnet__Q2_2nn2acFPUl(uint32_t *ip);
+nn::Result GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status(Status *status);
 nn::Result GetCompatId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(ConfigIdNum *id);
 nn::Result GetConnectResult__Q2_2nn2acFPQ2_2nn6Result(nn::Result *result);
 nn::Result GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status(Status *status);
+nn::Result GetLastErrorCode__Q2_2nn2acFPUi(ErrorCode *error);
+nn::Result GetRunningConfig__Q2_2nn2acFP16netconf_profile_(Config *cfg);
 nn::Result GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(ConfigIdNum *id);
 nn::Result Initialize__Q2_2nn2acFv();
+nn::Result IsAnyKeepingConnect__Q2_2nn2acFPb(bool keeping);
 nn::Result IsApplicationConnected__Q2_2nn2acFPb(bool *connected);
+nn::Result IsAutoConnectionFatallyFailed__Q2_2nn2acFQ2_2nn6Result(nn::Result *failed);
 nn::Result IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb(ConfigIdNum id, bool *existing);
+nn::Result IsKeepingConnect__Q2_2nn2acFPb(bool *keeping);
+nn::Result IsReadyToConnect__Q2_2nn2acFPb(bool *ready);
 nn::Result ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_(ConfigIdNum id, Config *cfg);
 nn::Result SetCompatId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
 nn::Result SetStartupId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
+nn::Result WriteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPC16netconf_profile_(ConfigIdNum id, const Config *cfg);
 
 } // extern "C"
 } // namespace detail
@@ -101,9 +119,8 @@ Initialize()
 static inline void
 Finalize()
 {
-   return detail::Finalize__Q2_2nn2acFv();
+   detail::Finalize__Q2_2nn2acFv();
 }
-
 
 /**
  * Gets the default connection configuration id. This is the default as marked
@@ -189,9 +206,15 @@ ConnectAsync(const Config *cfg)
 }
 
 static inline nn::Result
+ConnectWithRetry()
+{
+   return detail::ConnectWithRetry__Q2_2nn2acFv();
+}
+
+static inline nn::Result
 GetConnectStatus(Status *status)
 {
-   return detail::GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status(&status_num);
+   return detail::GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status(status);
 }
 
 static inline nn::Result
@@ -207,9 +230,9 @@ Close()
 }
 
 static inline nn::Result
-GetCloseStatus()
+GetCloseStatus(Status *status)
 {
-   return detail::GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status();
+   return detail::GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status(status);
 }
 
 static inline nn::Result
@@ -218,11 +241,34 @@ CloseAll()
    return detail::CloseAll__Q2_2nn2acFv();
 }
 
+static inline nn::Result
+IsAnyKeepingConnect(bool *keeping)
+{
+   return detail::IsAnyKeepingConnect__Q2_2nn2acFPb(keeping);
+}
+
+static inline nn::Result
+IsKeepingConnect(bool *keeping)
+{
+   return detail::IsKeepingConnect__Q2_2nn2acFPb(keeping);
+}
+
+static inline nn::Result
+IsReadyToConnect(bool *ready)
+{
+   return detail::IsReadyToConnect__Q2_2nn2acFPb(ready);
+}
 
 static inline nn::Result
 IsApplicationConnected(bool *connected)
 {
    return detail::IsApplicationConnected__Q2_2nn2acFPb(connected);
+}
+
+static inline nn::Result
+IsAutoConnectionFatallyFailed(nn::Result *failed)
+{
+   return detail::IsAutoConnectionFatallyFailed__Q2_2nn2acFQ2_2nn6Result(failed);
 }
 
 /**
@@ -244,15 +290,81 @@ GetAssignedAddress(uint32_t *ip)
 }
 
 static inline nn::Result
+GetAssignedGateway(uint32_t *ip)
+{
+   return detail::GetAssignedGateway__Q2_2nn2acFPUl(ip);
+}
+
+static inline nn::Result
+GetAssignedSubnet(uint32_t *ip)
+{
+   return detail::GetAssignedSubnet__Q2_2nn2acFPUl(ip);
+}
+
+static inline nn::Result
+GetAssignedPreferedDns(uint32_t *ip)
+{
+   return detail::GetAssignedPreferedDns__Q2_2nn2acFPUl(ip);
+}
+
+static inline nn::Result
+GetAssignedAlternativeDns(uint32_t *ip)
+{
+   return detail::GetAssignedAlternativeDns__Q2_2nn2acFPUl(ip);
+}
+
+static inline nn::Result
 IsConfigExisting(ConfigIdNum id, bool *existing)
 {
    return detail::IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb(id, existing);
+}
+
+static inline void
+ClearConfig(Config *cfg)
+{
+   detail::ClearConfig__Q2_2nn2acFP16netconf_profile_(cfg);
+}
+
+static inline nn::Result
+GetRunningConfig(Config *cfg)
+{
+   return detail::GetRunningConfig__Q2_2nn2acFP16netconf_profile_(cfg);
 }
 
 static inline nn::Result
 ReadConfig(ConfigIdNum id, Config *cfg)
 {
    return detail::ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_(id, cfg);
+}
+
+static inline nn::Result
+WriteConfig(ConfigIdNum id, const Config *cfg)
+{
+   return detail::WriteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPC16netconf_profile_(id, cfg);
+}
+
+static inline nn::Result
+DeleteConfig(ConfigIdNum id)
+{
+   return detail::DeleteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
+}
+
+static inline nn::Result
+GetLastErrorCode(ErrorCode *error)
+{
+   return detail::GetLastErrorCode__Q2_2nn2acFPUi(error);
+}
+
+static inline nn::Result
+BeginLocalConnection(bool unknown)
+{
+   return detail::BeginLocalConnection__Q2_2nn2acFb(unknown);
+}
+
+static inline nn::Result
+EndLocalConnection()
+{
+   return detail::EndLocalConnection__Q2_2nn2acFv();
 }
 
 } // namespace ac

--- a/include/nn/ac/ac_cpp.h
+++ b/include/nn/ac/ac_cpp.h
@@ -28,7 +28,7 @@ namespace ac
 using ConfigIdNum = uint32_t;
 
 /**
- * The configuration for a given network profile.
+ * The configuration for a given network profile (from 1 to 6).
  * \sa NetConfCfg
  */
 using Config = NetConfCfg;
@@ -41,128 +41,38 @@ enum Status {
     STATUS_PROCESSING =  1,
 };
 
-/**
-* C++ linkage for the autoconnect API, see \link nn::ac \endlink for use.
- * Cafe provides mangled symbols for C++ APIs, so nn::ac is actually static
- * inline calls to the mangled symbols under nn::ac::detail.
- */
-namespace detail
-{
-extern "C"
-{
 
-nn::Result BeginLocalConnection__Q2_2nn2acFb(bool unknown);
-void       ClearConfig__Q2_2nn2acFP16netconf_profile_(Config *cfg);
-nn::Result Close__Q2_2nn2acFv();
-nn::Result CloseAll__Q2_2nn2acFv();
-nn::Result Connect__Q2_2nn2acFPC16netconf_profile_(const Config *cfg);
-nn::Result Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
-nn::Result Connect__Q2_2nn2acFv();
-nn::Result ConnectAsync__Q2_2nn2acFPC16netconf_profile_(const Config *cfg);
-nn::Result ConnectAsync__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
-nn::Result ConnectAsync__Q2_2nn2acFv();
-nn::Result ConnectWithRetry__Q2_2nn2acFv();
-nn::Result DeleteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
-nn::Result EndLocalConnection__Q2_2nn2acFv();
-void       Finalize__Q2_2nn2acFv();
-nn::Result GetAssignedAddress__Q2_2nn2acFPUl(uint32_t *ip);
-nn::Result GetAssignedAlternativeDns__Q2_2nn2acFPUl(uint32_t *ip);
-nn::Result GetAssignedGateway__Q2_2nn2acFPUl(uint32_t *ip);
-nn::Result GetAssignedPreferedDns__Q2_2nn2acFPUl(uint32_t *ip);
-nn::Result GetAssignedSubnet__Q2_2nn2acFPUl(uint32_t *ip);
-nn::Result GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status(Status *status);
-nn::Result GetCompatId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(ConfigIdNum *id);
-nn::Result GetConnectResult__Q2_2nn2acFPQ2_2nn6Result(nn::Result *result);
-nn::Result GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status(Status *status);
-nn::Result GetLastErrorCode__Q2_2nn2acFPUi(ErrorCode *error);
-nn::Result GetRunningConfig__Q2_2nn2acFP16netconf_profile_(Config *cfg);
-nn::Result GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(ConfigIdNum *id);
-nn::Result Initialize__Q2_2nn2acFv();
-nn::Result IsAnyKeepingConnect__Q2_2nn2acFPb(bool keeping);
-nn::Result IsApplicationConnected__Q2_2nn2acFPb(bool *connected);
-nn::Result IsAutoConnectionFatallyFailed__Q2_2nn2acFQ2_2nn6Result(nn::Result *failed);
-nn::Result IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb(ConfigIdNum id, bool *existing);
-nn::Result IsKeepingConnect__Q2_2nn2acFPb(bool *keeping);
-nn::Result IsReadyToConnect__Q2_2nn2acFPb(bool *ready);
-nn::Result ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_(ConfigIdNum id, Config *cfg);
-nn::Result SetCompatId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
-nn::Result SetStartupId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
-nn::Result WriteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPC16netconf_profile_(ConfigIdNum id, const Config *cfg);
+nn::Result
+BeginLocalConnection(bool unknown)
+    asm("BeginLocalConnection__Q2_2nn2acFb");
 
-} // extern "C"
-} // namespace detail
+void
+ClearConfig(Config *cfg)
+    asm("ClearConfig__Q2_2nn2acFP16netconf_profile_");
 
-/**
- * Initialise the Auto Connect library. Call this function before any other nn::ac
- * functions.
- *
- * \return
- * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
- * and \link nn::Result::IsFailure \endlink.
- *
- * \sa
- * - \link Finalize \endlink
- */
-static inline nn::Result
-Initialize()
-{
-   return detail::Initialize__Q2_2nn2acFv();
-}
+nn::Result
+Close()
+    asm("Close__Q2_2nn2acFv");
 
-/**
- * Cleanup the Auto Connect library. Do not call any nn::ac functions (other
- * than \link Initialize \endlink) after calling this function.
- *
- * \sa
- * - \link Initialize \endlink
- */
-static inline void
-Finalize()
-{
-   detail::Finalize__Q2_2nn2acFv();
-}
+nn::Result
+CloseAll()
+    asm("CloseAll__Q2_2nn2acFv");
 
-/**
- * Gets the default connection configuration id. This is the default as marked
- * in System Settings.
- *
- * \param id
- * A pointer to an \link ConfigIdNum \endlink to write the config ID to. Must
- * not be a \c nullptr.
- *
- * \return
- * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
- * and \link nn::Result::IsFailure \endlink.
- */
-static inline nn::Result
-GetStartupId(ConfigIdNum *id)
-{
-   return detail::GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(id);
-}
+nn::Result
+Connect(const Config *cfg)
+    asm("Connect__Q2_2nn2acFPC16netconf_profile_");
 
-static inline nn::Result
-SetStartupId(ConfigIdNum id)
-{
-   return detail::SetStartupId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
-}
+nn::Result
+Connect(ConfigIdNum id)
+    asm("Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
 
-static inline nn::Result
-GetCompatId(ConfigIdNum *id)
-{
-   return detail::GetCompatId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(id);
-}
-
-static inline nn::Result
-SetCompatId(ConfigIdNum id)
-{
-   return detail::SetCompatId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
-}
-
-static inline nn::Result
+nn::Result
 Connect()
-{
-   return detail::Connect__Q2_2nn2acFv();
-}
+    asm("Connect__Q2_2nn2acFv");
+
+nn::Result
+ConnectAsync(const Config *cfg)
+    asm("ConnectAsync__Q2_2nn2acFPC16netconf_profile_");
 
 /**
  * Connects to a network, using the configuration represented by the given
@@ -175,101 +85,36 @@ Connect()
  * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
  * and \link nn::Result::IsFailure \endlink.
  */
-static inline nn::Result
-Connect(ConfigIdNum id)
-{
-   return detail::Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
-}
-
-static inline nn::Result
-Connect(const Config *cfg)
-{
-   return detail::Connect__Q2_2nn2acFPC16netconf_profile_(cfg);
-}
-
-static inline nn::Result
-ConnectAsync()
-{
-   return detail::ConnectAsync__Q2_2nn2acFv();
-}
-
-static inline nn::Result
+nn::Result
 ConnectAsync(ConfigIdNum id)
-{
-   return detail::ConnectAsync__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
-}
+    asm("ConnectAsync__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
 
-static inline nn::Result
-ConnectAsync(const Config *cfg)
-{
-   return detail::ConnectAsync__Q2_2nn2acFPC16netconf_profile_(cfg);
-}
+nn::Result
+ConnectAsync()
+    asm("ConnectAsync__Q2_2nn2acFv");
 
-static inline nn::Result
+nn::Result
 ConnectWithRetry()
-{
-   return detail::ConnectWithRetry__Q2_2nn2acFv();
-}
+    asm("ConnectWithRetry__Q2_2nn2acFv");
 
-static inline nn::Result
-GetConnectStatus(Status *status)
-{
-   return detail::GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status(status);
-}
+nn::Result
+DeleteConfig(ConfigIdNum id)
+    asm("DeleteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
 
-static inline nn::Result
-GetConnectResult(nn::Result *result)
-{
-   return detail::GetConnectResult__Q2_2nn2acFPQ2_2nn6Result(result);
-}
+nn::Result
+EndLocalConnection()
+    asm("EndLocalConnection__Q2_2nn2acFv");
 
-static inline nn::Result
-Close()
-{
-   return detail::Close__Q2_2nn2acFv();
-}
-
-static inline nn::Result
-GetCloseStatus(Status *status)
-{
-   return detail::GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status(status);
-}
-
-static inline nn::Result
-CloseAll()
-{
-   return detail::CloseAll__Q2_2nn2acFv();
-}
-
-static inline nn::Result
-IsAnyKeepingConnect(bool *keeping)
-{
-   return detail::IsAnyKeepingConnect__Q2_2nn2acFPb(keeping);
-}
-
-static inline nn::Result
-IsKeepingConnect(bool *keeping)
-{
-   return detail::IsKeepingConnect__Q2_2nn2acFPb(keeping);
-}
-
-static inline nn::Result
-IsReadyToConnect(bool *ready)
-{
-   return detail::IsReadyToConnect__Q2_2nn2acFPb(ready);
-}
-
-static inline nn::Result
-IsApplicationConnected(bool *connected)
-{
-   return detail::IsApplicationConnected__Q2_2nn2acFPb(connected);
-}
-
-static inline nn::Result
-IsAutoConnectionFatallyFailed(nn::Result *failed)
-{
-   return detail::IsAutoConnectionFatallyFailed__Q2_2nn2acFQ2_2nn6Result(failed);
-}
+/**
+ * Cleans up the Auto Connect library. Do not call any nn::ac functions (other
+ * than \link Initialize \endlink) after calling this function.
+ *
+ * \sa
+ * - \link Initialize \endlink
+ */
+void
+Finalize()
+    asm("Finalize__Q2_2nn2acFv");
 
 /**
  * Gets the IP address assosciated with the currently active connection.
@@ -283,89 +128,120 @@ IsAutoConnectionFatallyFailed(nn::Result *failed)
  * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
  * and \link nn::Result::IsFailure \endlink.
  */
-static inline nn::Result
+nn::Result
 GetAssignedAddress(uint32_t *ip)
-{
-   return detail::GetAssignedAddress__Q2_2nn2acFPUl(ip);
-}
+    asm("GetAssignedAddress__Q2_2nn2acFPUl");
 
-static inline nn::Result
-GetAssignedGateway(uint32_t *ip)
-{
-   return detail::GetAssignedGateway__Q2_2nn2acFPUl(ip);
-}
-
-static inline nn::Result
-GetAssignedSubnet(uint32_t *ip)
-{
-   return detail::GetAssignedSubnet__Q2_2nn2acFPUl(ip);
-}
-
-static inline nn::Result
-GetAssignedPreferedDns(uint32_t *ip)
-{
-   return detail::GetAssignedPreferedDns__Q2_2nn2acFPUl(ip);
-}
-
-static inline nn::Result
+nn::Result
 GetAssignedAlternativeDns(uint32_t *ip)
-{
-   return detail::GetAssignedAlternativeDns__Q2_2nn2acFPUl(ip);
-}
+    asm("GetAssignedAlternativeDns__Q2_2nn2acFPUl");
 
-static inline nn::Result
-IsConfigExisting(ConfigIdNum id, bool *existing)
-{
-   return detail::IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb(id, existing);
-}
+nn::Result
+GetAssignedGateway(uint32_t *ip)
+    asm("GetAssignedGateway__Q2_2nn2acFPUl");
 
-static inline void
-ClearConfig(Config *cfg)
-{
-   detail::ClearConfig__Q2_2nn2acFP16netconf_profile_(cfg);
-}
+nn::Result
+GetAssignedPreferedDns(uint32_t *ip)
+    asm("GetAssignedPreferedDns__Q2_2nn2acFPUl");
 
-static inline nn::Result
-GetRunningConfig(Config *cfg)
-{
-   return detail::GetRunningConfig__Q2_2nn2acFP16netconf_profile_(cfg);
-}
+nn::Result
+GetAssignedSubnet(uint32_t *ip)
+    asm("GetAssignedSubnet__Q2_2nn2acFPUl");
 
-static inline nn::Result
-ReadConfig(ConfigIdNum id, Config *cfg)
-{
-   return detail::ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_(id, cfg);
-}
+nn::Result
+GetCloseStatus(Status *status)
+    asm("GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status");
 
-static inline nn::Result
-WriteConfig(ConfigIdNum id, const Config *cfg)
-{
-   return detail::WriteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPC16netconf_profile_(id, cfg);
-}
+nn::Result
+GetCompatId(ConfigIdNum *id)
+    asm("GetCompatId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum");
 
-static inline nn::Result
-DeleteConfig(ConfigIdNum id)
-{
-   return detail::DeleteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
-}
+nn::Result
+GetConnectResult(nn::Result *result)
+    asm("GetConnectResult__Q2_2nn2acFPQ2_2nn6Result");
 
-static inline nn::Result
+nn::Result
+GetConnectStatus(Status *status)
+    asm("GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status");
+
+nn::Result
 GetLastErrorCode(ErrorCode *error)
-{
-   return detail::GetLastErrorCode__Q2_2nn2acFPUi(error);
-}
+    asm("GetLastErrorCode__Q2_2nn2acFPUi");
 
-static inline nn::Result
-BeginLocalConnection(bool unknown)
-{
-   return detail::BeginLocalConnection__Q2_2nn2acFb(unknown);
-}
+nn::Result
+GetRunningConfig(Config *cfg)
+    asm("GetRunningConfig__Q2_2nn2acFP16netconf_profile_");
 
-static inline nn::Result
-EndLocalConnection()
-{
-   return detail::EndLocalConnection__Q2_2nn2acFv();
-}
+/**
+ * Gets the default connection configuration id. This is the default as marked
+ * in System Settings.
+ *
+ * \param id
+ * A pointer to an \link ConfigIdNum \endlink to write the config ID to. Must
+ * not be a \c nullptr.
+ *
+ * \return
+ * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
+ * and \link nn::Result::IsFailure \endlink.
+ */
+nn::Result
+GetStartupId(ConfigIdNum *id)
+    asm("GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum");
+
+/**
+ * Initializes the Auto Connect library. Call this function before any other nn::ac
+ * functions.
+ *
+ * \return
+ * A \link nn::Result Result\endlink - see \link nn::Result::IsSuccess \endlink
+ * and \link nn::Result::IsFailure \endlink.
+ *
+ * \sa
+ * - \link Finalize \endlink
+ */
+nn::Result
+Initialize()
+    asm("Initialize__Q2_2nn2acFv");
+
+nn::Result
+IsAnyKeepingConnect(bool keeping)
+    asm("IsAnyKeepingConnect__Q2_2nn2acFPb");
+
+nn::Result
+IsApplicationConnected(bool *connected)
+    asm("IsApplicationConnected__Q2_2nn2acFPb");
+
+nn::Result
+IsAutoConnectionFatallyFailed(nn::Result *failed)
+    asm("IsAutoConnectionFatallyFailed__Q2_2nn2acFQ2_2nn6Result");
+
+nn::Result
+IsConfigExisting(ConfigIdNum id, bool *existing)
+    asm("IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb");
+
+nn::Result
+IsKeepingConnect(bool *keeping)
+    asm("IsKeepingConnect__Q2_2nn2acFPb");
+
+nn::Result
+IsReadyToConnect(bool *ready)
+    asm("IsReadyToConnect__Q2_2nn2acFPb");
+
+nn::Result
+ReadConfig(ConfigIdNum id, Config *cfg)
+    asm("ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_");
+
+nn::Result
+SetCompatId(ConfigIdNum id)
+    asm("SetCompatId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
+
+nn::Result
+SetStartupId(ConfigIdNum id)
+    asm("SetStartupId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
+
+nn::Result
+WriteConfig(ConfigIdNum id, const Config *cfg)
+    asm("WriteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPC16netconf_profile_");
 
 } // namespace ac
 } // namespace nn

--- a/include/nn/ac/ac_cpp.h
+++ b/include/nn/ac/ac_cpp.h
@@ -36,43 +36,43 @@ using Config = NetConfCfg;
 using ErrorCode = uint32_t;
 
 enum Status {
-    STATUS_FAILED     = -1,
-    STATUS_OK         =  0,
-    STATUS_PROCESSING =  1,
+   STATUS_FAILED     = -1,
+   STATUS_OK         =  0,
+   STATUS_PROCESSING =  1,
 };
 
 
 nn::Result
 BeginLocalConnection(bool unknown)
-    asm("BeginLocalConnection__Q2_2nn2acFb");
+   asm("BeginLocalConnection__Q2_2nn2acFb");
 
 void
 ClearConfig(Config *cfg)
-    asm("ClearConfig__Q2_2nn2acFP16netconf_profile_");
+   asm("ClearConfig__Q2_2nn2acFP16netconf_profile_");
 
 nn::Result
 Close()
-    asm("Close__Q2_2nn2acFv");
+   asm("Close__Q2_2nn2acFv");
 
 nn::Result
 CloseAll()
-    asm("CloseAll__Q2_2nn2acFv");
+   asm("CloseAll__Q2_2nn2acFv");
 
 nn::Result
 Connect(const Config *cfg)
-    asm("Connect__Q2_2nn2acFPC16netconf_profile_");
+   asm("Connect__Q2_2nn2acFPC16netconf_profile_");
 
 nn::Result
 Connect(ConfigIdNum id)
-    asm("Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
+   asm("Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
 
 nn::Result
 Connect()
-    asm("Connect__Q2_2nn2acFv");
+   asm("Connect__Q2_2nn2acFv");
 
 nn::Result
 ConnectAsync(const Config *cfg)
-    asm("ConnectAsync__Q2_2nn2acFPC16netconf_profile_");
+   asm("ConnectAsync__Q2_2nn2acFPC16netconf_profile_");
 
 /**
  * Connects to a network, using the configuration represented by the given
@@ -87,23 +87,23 @@ ConnectAsync(const Config *cfg)
  */
 nn::Result
 ConnectAsync(ConfigIdNum id)
-    asm("ConnectAsync__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
+   asm("ConnectAsync__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
 
 nn::Result
 ConnectAsync()
-    asm("ConnectAsync__Q2_2nn2acFv");
+   asm("ConnectAsync__Q2_2nn2acFv");
 
 nn::Result
 ConnectWithRetry()
-    asm("ConnectWithRetry__Q2_2nn2acFv");
+   asm("ConnectWithRetry__Q2_2nn2acFv");
 
 nn::Result
 DeleteConfig(ConfigIdNum id)
-    asm("DeleteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
+   asm("DeleteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
 
 nn::Result
 EndLocalConnection()
-    asm("EndLocalConnection__Q2_2nn2acFv");
+   asm("EndLocalConnection__Q2_2nn2acFv");
 
 /**
  * Cleans up the Auto Connect library. Do not call any nn::ac functions (other
@@ -114,7 +114,7 @@ EndLocalConnection()
  */
 void
 Finalize()
-    asm("Finalize__Q2_2nn2acFv");
+   asm("Finalize__Q2_2nn2acFv");
 
 /**
  * Gets the IP address assosciated with the currently active connection.
@@ -130,47 +130,47 @@ Finalize()
  */
 nn::Result
 GetAssignedAddress(uint32_t *ip)
-    asm("GetAssignedAddress__Q2_2nn2acFPUl");
+   asm("GetAssignedAddress__Q2_2nn2acFPUl");
 
 nn::Result
 GetAssignedAlternativeDns(uint32_t *ip)
-    asm("GetAssignedAlternativeDns__Q2_2nn2acFPUl");
+   asm("GetAssignedAlternativeDns__Q2_2nn2acFPUl");
 
 nn::Result
 GetAssignedGateway(uint32_t *ip)
-    asm("GetAssignedGateway__Q2_2nn2acFPUl");
+   asm("GetAssignedGateway__Q2_2nn2acFPUl");
 
 nn::Result
 GetAssignedPreferedDns(uint32_t *ip)
-    asm("GetAssignedPreferedDns__Q2_2nn2acFPUl");
+   asm("GetAssignedPreferedDns__Q2_2nn2acFPUl");
 
 nn::Result
 GetAssignedSubnet(uint32_t *ip)
-    asm("GetAssignedSubnet__Q2_2nn2acFPUl");
+   asm("GetAssignedSubnet__Q2_2nn2acFPUl");
 
 nn::Result
 GetCloseStatus(Status *status)
-    asm("GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status");
+   asm("GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status");
 
 nn::Result
 GetCompatId(ConfigIdNum *id)
-    asm("GetCompatId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum");
+   asm("GetCompatId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum");
 
 nn::Result
 GetConnectResult(nn::Result *result)
-    asm("GetConnectResult__Q2_2nn2acFPQ2_2nn6Result");
+   asm("GetConnectResult__Q2_2nn2acFPQ2_2nn6Result");
 
 nn::Result
 GetConnectStatus(Status *status)
-    asm("GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status");
+   asm("GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status");
 
 nn::Result
 GetLastErrorCode(ErrorCode *error)
-    asm("GetLastErrorCode__Q2_2nn2acFPUi");
+   asm("GetLastErrorCode__Q2_2nn2acFPUi");
 
 nn::Result
 GetRunningConfig(Config *cfg)
-    asm("GetRunningConfig__Q2_2nn2acFP16netconf_profile_");
+   asm("GetRunningConfig__Q2_2nn2acFP16netconf_profile_");
 
 /**
  * Gets the default connection configuration id. This is the default as marked
@@ -186,7 +186,7 @@ GetRunningConfig(Config *cfg)
  */
 nn::Result
 GetStartupId(ConfigIdNum *id)
-    asm("GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum");
+   asm("GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum");
 
 /**
  * Initializes the Auto Connect library. Call this function before any other nn::ac
@@ -201,47 +201,47 @@ GetStartupId(ConfigIdNum *id)
  */
 nn::Result
 Initialize()
-    asm("Initialize__Q2_2nn2acFv");
+   asm("Initialize__Q2_2nn2acFv");
 
 nn::Result
 IsAnyKeepingConnect(bool keeping)
-    asm("IsAnyKeepingConnect__Q2_2nn2acFPb");
+   asm("IsAnyKeepingConnect__Q2_2nn2acFPb");
 
 nn::Result
 IsApplicationConnected(bool *connected)
-    asm("IsApplicationConnected__Q2_2nn2acFPb");
+   asm("IsApplicationConnected__Q2_2nn2acFPb");
 
 nn::Result
 IsAutoConnectionFatallyFailed(nn::Result *failed)
-    asm("IsAutoConnectionFatallyFailed__Q2_2nn2acFQ2_2nn6Result");
+   asm("IsAutoConnectionFatallyFailed__Q2_2nn2acFQ2_2nn6Result");
 
 nn::Result
 IsConfigExisting(ConfigIdNum id, bool *existing)
-    asm("IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb");
+   asm("IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb");
 
 nn::Result
 IsKeepingConnect(bool *keeping)
-    asm("IsKeepingConnect__Q2_2nn2acFPb");
+   asm("IsKeepingConnect__Q2_2nn2acFPb");
 
 nn::Result
 IsReadyToConnect(bool *ready)
-    asm("IsReadyToConnect__Q2_2nn2acFPb");
+   asm("IsReadyToConnect__Q2_2nn2acFPb");
 
 nn::Result
 ReadConfig(ConfigIdNum id, Config *cfg)
-    asm("ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_");
+   asm("ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_");
 
 nn::Result
 SetCompatId(ConfigIdNum id)
-    asm("SetCompatId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
+   asm("SetCompatId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
 
 nn::Result
 SetStartupId(ConfigIdNum id)
-    asm("SetStartupId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
+   asm("SetStartupId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum");
 
 nn::Result
 WriteConfig(ConfigIdNum id, const Config *cfg)
-    asm("WriteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPC16netconf_profile_");
+   asm("WriteConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPC16netconf_profile_");
 
 } // namespace ac
 } // namespace nn

--- a/include/nn/ac/ac_cpp.h
+++ b/include/nn/ac/ac_cpp.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <wut.h>
 #include <nn/result.h>
+#include <nsysnet/netconfig.h>
 
 /**
  * \defgroup nn_ac_cpp Auto Connect C++ API
@@ -27,7 +28,19 @@ namespace ac
 typedef uint32_t ConfigIdNum;
 
 /**
- * C++ linkage for the autoconnect API, see \link nn::ac \endlink for use.
+ * The configuration for a given network profile.
+ * \sa NetConfCfg
+ */
+using Config = NetConfCfg;
+
+enum Status {
+    STATUS_FAILED     = -1,
+    STATUS_OK         = 0,
+    STATUS_PROCESSING = 1,
+};
+
+/**
+* C++ linkage for the autoconnect API, see \link nn::ac \endlink for use.
  * Cafe provides mangled symbols for C++ APIs, so nn::ac is actually static
  * inline calls to the mangled symbols under nn::ac::detail.
  */
@@ -36,15 +49,27 @@ namespace detail
 extern "C"
 {
 
-nn::Result Initialize__Q2_2nn2acFv();
-void Finalize__Q2_2nn2acFv();
-nn::Result Connect__Q2_2nn2acFv();
-nn::Result ConnectAsync__Q2_2nn2acFv();
 nn::Result Close__Q2_2nn2acFv();
-nn::Result GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status();
-nn::Result GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(ConfigIdNum *id);
+nn::Result CloseAll__Q2_2nn2acFv();
+nn::Result Connect__Q2_2nn2acFPC16netconf_profile_(const Config *cfg);
 nn::Result Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
+nn::Result Connect__Q2_2nn2acFv();
+nn::Result ConnectAsync__Q2_2nn2acFPC16netconf_profile_(const Config *cfg);
+nn::Result ConnectAsync__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
+nn::Result ConnectAsync__Q2_2nn2acFv();
+void       Finalize__Q2_2nn2acFv();
 nn::Result GetAssignedAddress__Q2_2nn2acFPUl(uint32_t *ip);
+nn::Result GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status();
+nn::Result GetCompatId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(ConfigIdNum *id);
+nn::Result GetConnectResult__Q2_2nn2acFPQ2_2nn6Result(nn::Result *result);
+nn::Result GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status(Status *status);
+nn::Result GetStartupId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(ConfigIdNum *id);
+nn::Result Initialize__Q2_2nn2acFv();
+nn::Result IsApplicationConnected__Q2_2nn2acFPb(bool *connected);
+nn::Result IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb(ConfigIdNum id, bool *existing);
+nn::Result ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_(ConfigIdNum id, Config *cfg);
+nn::Result SetCompatId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
+nn::Result SetStartupId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(ConfigIdNum id);
 
 } // extern "C"
 } // namespace detail
@@ -99,27 +124,27 @@ GetStartupId(ConfigIdNum *id)
 }
 
 static inline nn::Result
+SetStartupId(ConfigIdNum id)
+{
+   return detail::SetStartupId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
+}
+
+static inline nn::Result
+GetCompatId(ConfigIdNum *id)
+{
+   return detail::GetCompatId__Q2_2nn2acFPQ3_2nn2ac11ConfigIdNum(id);
+}
+
+static inline nn::Result
+SetCompatId(ConfigIdNum id)
+{
+   return detail::SetCompatId__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
+}
+
+static inline nn::Result
 Connect()
 {
    return detail::Connect__Q2_2nn2acFv();
-}
-
-static inline nn::Result
-ConnectAsync()
-{
-   return detail::ConnectAsync__Q2_2nn2acFv();
-}
-
-static inline nn::Result
-Close()
-{
-   return detail::Close__Q2_2nn2acFv();
-}
-
-static inline nn::Result
-GetCloseStatus()
-{
-   return detail::GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status();
 }
 
 /**
@@ -139,6 +164,67 @@ Connect(ConfigIdNum id)
    return detail::Connect__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
 }
 
+static inline nn::Result
+Connect(const Config *cfg)
+{
+   return detail::Connect__Q2_2nn2acFPC16netconf_profile_(cfg);
+}
+
+static inline nn::Result
+ConnectAsync()
+{
+   return detail::ConnectAsync__Q2_2nn2acFv();
+}
+
+static inline nn::Result
+ConnectAsync(ConfigIdNum id)
+{
+   return detail::ConnectAsync__Q2_2nn2acFQ3_2nn2ac11ConfigIdNum(id);
+}
+
+static inline nn::Result
+ConnectAsync(const Config *cfg)
+{
+   return detail::ConnectAsync__Q2_2nn2acFPC16netconf_profile_(cfg);
+}
+
+static inline nn::Result
+GetConnectStatus(Status *status)
+{
+   return detail::GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status(&status_num);
+}
+
+static inline nn::Result
+GetConnectResult(nn::Result *result)
+{
+   return detail::GetConnectResult__Q2_2nn2acFPQ2_2nn6Result(result);
+}
+
+static inline nn::Result
+Close()
+{
+   return detail::Close__Q2_2nn2acFv();
+}
+
+static inline nn::Result
+GetCloseStatus()
+{
+   return detail::GetCloseStatus__Q2_2nn2acFPQ3_2nn2ac6Status();
+}
+
+static inline nn::Result
+CloseAll()
+{
+   return detail::CloseAll__Q2_2nn2acFv();
+}
+
+
+static inline nn::Result
+IsApplicationConnected(bool *connected)
+{
+   return detail::IsApplicationConnected__Q2_2nn2acFPb(connected);
+}
+
 /**
  * Gets the IP address assosciated with the currently active connection.
  *
@@ -155,6 +241,18 @@ static inline nn::Result
 GetAssignedAddress(uint32_t *ip)
 {
    return detail::GetAssignedAddress__Q2_2nn2acFPUl(ip);
+}
+
+static inline nn::Result
+IsConfigExisting(ConfigIdNum id, bool *existing)
+{
+   return detail::IsConfigExisting__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumPb(id, existing);
+}
+
+static inline nn::Result
+ReadConfig(ConfigIdNum id, Config *cfg)
+{
+   return detail::ReadConfig__Q2_2nn2acFQ3_2nn2ac11ConfigIdNumP16netconf_profile_(id, cfg);
 }
 
 } // namespace ac

--- a/include/nn/result.h
+++ b/include/nn/result.h
@@ -228,6 +228,11 @@ public:
    };
 
 public:
+   Result() :
+      mValue(0)
+   {
+   }
+
    Result(Level level, Module module, unsigned description) :
       mValue(((level & 0x7) << 29) | ((module & 0x1FF) << 20) | (description & 0xFFFFF))
    {

--- a/include/nsysnet/netconfig.h
+++ b/include/nsysnet/netconfig.h
@@ -198,10 +198,7 @@ WUT_CHECK_SIZE(NetConfOpt, 0x2c1);
 
 struct WUT_PACKED NetConfInterface {
     uint16_t if_index;
-    union {
-        uint16_t if_state;
-        uint16_t if_sate;
-    };
+    uint16_t if_state;
     uint32_t if_mtu;
     NetConfIPv4Info ipv4Info;
 };

--- a/include/nsysnet/netconfig.h
+++ b/include/nsysnet/netconfig.h
@@ -198,7 +198,10 @@ WUT_CHECK_SIZE(NetConfOpt, 0x2c1);
 
 struct WUT_PACKED NetConfInterface {
     uint16_t if_index;
-    uint16_t if_state;
+    union {
+        uint16_t if_state;
+        uint16_t if_sate;
+    };
     uint32_t if_mtu;
     NetConfIPv4Info ipv4Info;
 };

--- a/include/nsysnet/netconfig.h
+++ b/include/nsysnet/netconfig.h
@@ -174,7 +174,7 @@ WUT_CHECK_OFFSET(NetConfWifiConfigDataPrivacy, 0x06, aes_key);
 WUT_CHECK_SIZE(NetConfWifiConfigDataPrivacy, 0x48);
 
 struct WUT_PACKED NetConfWifiConfigData {
-    uint8_t ssid[0x20];
+    char ssid[0x20];
     uint16_t ssidlength;
     WUT_PADDING_BYTES(2);
     NetConfWifiConfigDataPrivacy privacy;
@@ -198,7 +198,7 @@ WUT_CHECK_SIZE(NetConfOpt, 0x2c1);
 
 struct WUT_PACKED NetConfInterface {
     uint16_t if_index;
-    uint16_t if_sate;
+    uint16_t if_state;
     uint32_t if_mtu;
     NetConfIPv4Info ipv4Info;
 };

--- a/include/nsysnet/netconfig.h
+++ b/include/nsysnet/netconfig.h
@@ -203,7 +203,7 @@ struct WUT_PACKED NetConfInterface {
     NetConfIPv4Info ipv4Info;
 };
 WUT_CHECK_OFFSET(NetConfInterface, 0x00, if_index);
-WUT_CHECK_OFFSET(NetConfInterface, 0x02, if_sate);
+WUT_CHECK_OFFSET(NetConfInterface, 0x02, if_state);
 WUT_CHECK_OFFSET(NetConfInterface, 0x04, if_mtu);
 WUT_CHECK_OFFSET(NetConfInterface, 0x08, ipv4Info);
 WUT_CHECK_SIZE(NetConfInterface, 0x20);


### PR DESCRIPTION
In `nsysnet/netconfig.h`:
- Changed type of `.ssid` in `NetConfWifiConfigData` to be a `char` array because it's a string.
- Fix typo in `NetConfInterface`: `.if_sate` -> `.if_state`.

In `nn/result.h`:
- Added a default constructor for `nn::Result`: we need to variables of this type to pass as an output argument to some functions.

In `nn/ac/ac_cpp.h`:
- Fixed wrong signature for `nn::ac::GetCloseStatus()`, and added the corresponding `nn::ac::Status` enum.
- Added a few more functions.
- Added the `nn::ac::Config` type alias to `NetConfCfg`.