### PR TITLE
Add missing include

### DIFF
--- a/libraries/wutnewlib/wut_reent.c
+++ b/libraries/wutnewlib/wut_reent.c
@@ -1,6 +1,7 @@
 #include "wut_newlib.h"
 #include "wut_thread_specific.h"
 #include <stdlib.h>
+#include <string.h>
 
 #include <coreinit/thread.h>
 


### PR DESCRIPTION
When compiling wut with powerpc-eabi-gcc (devkitPPC release 46) 14.2.0 I'm getting this error:

```
wut_reent.c
In file included from /opt/devkitpro/devkitPPC/powerpc-eabi/include/sys/errno.h:11,
                 from /workspaces/wut/libraries/wutnewlib/wut_newlib.h:4,
                 from /workspaces/wut/libraries/wutnewlib/wut_reent.c:1:
/workspaces/wut/libraries/wutnewlib/wut_reent.c: In function '__wut_getreent':
/workspaces/wut/libraries/wutnewlib/wut_reent.c:56:7: error: implicit declaration of function 'memset' [-Wimplicit-function-declaration]
   56 |       _REENT_INIT_PTR(&context->reent);
      |       ^~~~~~~~~~~~~~~
/workspaces/wut/libraries/wutnewlib/wut_reent.c:6:1: note: include '<string.h>' or provide a declaration of 'memset'
    5 | #include <coreinit/thread.h>
  +++ |+#include <string.h>
    6 | 
make[1]: *** [/opt/devkitpro/devkitPPC/base_rules:21: wut_reent.o] Error 1
make: *** [Makefile:135: lib/libwut.a] Error 2
```

Toolchain info:
```
root@f74a9060e6a6:/workspaces/wut# /opt/devkitpro/devkitPPC/bin/powerpc-eabi-gcc --version
powerpc-eabi-gcc (devkitPPC release 46) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

It's possible there is better fix, but I did what compiler told me 🙄