### PR TITLE
add H264_ERROR_DECODE_SUCCESS to stream.h

### DIFF
--- a/include/h264/stream.h
+++ b/include/h264/stream.h
@@ -31,6 +31,9 @@ typedef enum H264Error
    //! Invalid slice header.
    H264_ERROR_INVALID_SLICEHEADER      = 61,
 
+   //! H264DECExecute decoded successfully.
+   H264_ERROR_DECODE_SUCCESS           = 228,
+
    //! Generic h264 error.
    H264_ERROR_GENERIC                  = 0x1000000,
 


### PR DESCRIPTION
221 is used as a success code by H264DECExecute, but this isn't listed in the docs or enum. So now it is.