### PR TITLE
Update version number in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TOPDIR ?= $(CURDIR)
 include $(TOPDIR)/share/wut_rules
 
 export WUT_MAJOR	:=	1
-export WUT_MINOR	:=	4
+export WUT_MINOR	:=	7
 export WUT_PATCH	:=	0
 
 VERSION	:=	$(WUT_MAJOR).$(WUT_MINOR).$(WUT_PATCH)


### PR DESCRIPTION
The version number in the Makefile has been neglected for a while. This changes it to match the latest release.