### PR TITLE
coreinit/thread: `OSThreadEntryPointFn` and `OSCreateThread` take `void*` for arg

### DIFF
--- a/include/coreinit/thread.h
+++ b/include/coreinit/thread.h
@@ -53,7 +53,7 @@ typedef uint8_t OSThreadAttributes;
 //! A bitfield of enum OS_THREAD_TYPE.
 typedef uint32_t OSThreadType;
 
-typedef int (*OSThreadEntryPointFn)(int argc, const char **argv);
+typedef int (*OSThreadEntryPointFn)(int argc, void *argv);
 typedef void (*OSThreadCleanupCallbackFn)(OSThread *thread, void *stack);
 typedef void (*OSThreadDeallocatorFn)(OSThread *thread, void *stack);
 
@@ -433,7 +433,7 @@ BOOL
 OSCreateThread(OSThread *thread,
                OSThreadEntryPointFn entry,
                int32_t argc,
-               char *argv,
+               void *argv,
                void *stack,
                uint32_t stackSize,
                int32_t priority,

--- a/libraries/libwhb/src/crash.c
+++ b/libraries/libwhb/src/crash.c
@@ -44,7 +44,7 @@ static OSThread __attribute__((aligned(8)))
 sCrashThread;
 
 static int
-crashReportThread(int argc, const char **argv)
+crashReportThread(int argc, void* argv)
 {
    // Log crash dump
    WHBLogPrint(sRegistersBuffer);


### PR DESCRIPTION
There's no reason for `OSThreadEntryPointFn` to take `const char**` when `argv` uses the value that is `char*` in `OSCreateThread`, there's also no reason for params to be `char` related when they're not type restricted 