### PR TITLE
Fix crash due to incorrect OSReport() usage.

### DIFF
--- a/libraries/libwhb/src/log_cafe.c
+++ b/libraries/libwhb/src/log_cafe.c
@@ -11,7 +11,7 @@ cafeLogHandler(const char *msg)
    if (msg[length - 1] != '\n') {
       OSReport("%s\n", msg);
    } else {
-      OSReport(msg);
+      OSReport("%s", msg);
    }
 }
 

--- a/libraries/nn_erreula/nn_erreula.cpp
+++ b/libraries/nn_erreula/nn_erreula.cpp
@@ -88,12 +88,12 @@ Create(const CreateArg &args)
    bool result                       = true;
 
    if (!args.workMemory) {
-      OSReport("ERREULA: Create failed. CreateArg.workMemory is NULL.");
+      OSReport("ERREULA: Create failed. CreateArg.workMemory is NULL.\n");
       return false;
    }
 
    if (!args.fsClient) {
-      OSReport("ERREULA: Create failed. CreateArg.fsClient is NULL.");
+      OSReport("ERREULA: Create failed. CreateArg.fsClient is NULL.\n");
       return false;
    }
 
@@ -114,7 +114,7 @@ Create(const CreateArg &args)
             dynloadAcquireUseSize, kRplAcquireBufferSize);
 
    if (dynloadAcquireUseSize > kRplAcquireBufferSize) {
-      OSReport("ERREULA: Create failed. dynload_acquire_use_size > kRplAcquireBufferSize.");
+      OSReport("ERREULA: Create failed. dynload_acquire_use_size > kRplAcquireBufferSize.\n");
       result = false;
       goto out;
    }
@@ -147,7 +147,7 @@ Create(const CreateArg &args)
                                       kWorkMemorySize - kRplAcquireBufferSize,
                                       4);
    if (!workMemory) {
-      OSReport("ERREULA: Create failed. framework_buffer == NULL.");
+      OSReport("ERREULA: Create failed. framework_buffer == NULL.\n");
       result = false;
       goto out;
    } else {

--- a/libraries/nn_swkbd/nn_swkbd.cpp
+++ b/libraries/nn_swkbd/nn_swkbd.cpp
@@ -99,12 +99,12 @@ Create(const CreateArg &args)
    bool result                       = true;
 
    if (!args.workMemory) {
-      OSReport("SWKBD: Create failed. CreateArg.workMemory is NULL.");
+      OSReport("SWKBD: Create failed. CreateArg.workMemory is NULL.\n");
       return false;
    }
 
    if (!args.fsClient) {
-      OSReport("SWKBD: Create failed. CreateArg.fsClient is NULL.");
+      OSReport("SWKBD: Create failed. CreateArg.fsClient is NULL.\n");
       return false;
    }
 
@@ -132,7 +132,7 @@ Create(const CreateArg &args)
             dynloadAcquireUseSize, sRplAcquireBufferSize);
 
    if (dynloadAcquireUseSize > sRplAcquireBufferSize) {
-      OSReport("SWKBD: Create failed. dynload_acquire_use_size > sRplAcquireBufferSize.");
+      OSReport("SWKBD: Create failed. dynload_acquire_use_size > sRplAcquireBufferSize.\n");
       result = false;
       goto out;
    }
@@ -178,7 +178,7 @@ Create(const CreateArg &args)
                                       GetWorkMemorySize(args.unk_0x08) - sRplAcquireBufferSize,
                                       4);
    if (!workMemory) {
-      OSReport("SWKBD: Create failed. framework_buffer == NULL.");
+      OSReport("SWKBD: Create failed. framework_buffer == NULL.\n");
       result = false;
       goto out;
    } else {


### PR DESCRIPTION
Sending messages ending with `\n` to log_cafe leads to a bad `OSReport()` call, with **no format string**. The input string is used as the format string, usually leading to crashes when the string has `%`.

In addition to fixing the incorrect `OSReport()` call, this PR also ensures all error messages being printed by `OSReport()` have a proper `\n` at the end.