### PR TITLE
Increase minimum CMake required in tests and samples.

### DIFF
--- a/samples/cmake/CMakeLists.txt
+++ b/samples/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(samples)
 
 add_subdirectory(custom_default_heap)

--- a/samples/cmake/custom_default_heap/CMakeLists.txt
+++ b/samples/cmake/custom_default_heap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(custom_default_heap C)
 
 add_executable(custom_default_heap

--- a/samples/cmake/erreula/CMakeLists.txt
+++ b/samples/cmake/erreula/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(erreula CXX)
 
 add_executable(erreula

--- a/samples/cmake/gx2_triangle/CMakeLists.txt
+++ b/samples/cmake/gx2_triangle/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(gx2_triangle C)
 
 add_executable(gx2_triangle

--- a/samples/cmake/helloworld/CMakeLists.txt
+++ b/samples/cmake/helloworld/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(helloworld C)
 
 add_executable(helloworld

--- a/samples/cmake/helloworld_cpp/CMakeLists.txt
+++ b/samples/cmake/helloworld_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(helloworld_cpp CXX)
 
 add_executable(helloworld_cpp

--- a/samples/cmake/my_first_rpl/CMakeLists.txt
+++ b/samples/cmake/my_first_rpl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(my_first_rpl C)
 
 add_executable(my_first_rpl my_first_rpl.c)

--- a/samples/cmake/swkbd/CMakeLists.txt
+++ b/samples/cmake/swkbd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(swkbd CXX)
 
 add_executable(swkbd

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(tests)
 
 include_directories("test_compile_headers_common")

--- a/tests/test_compile_headers_as_c11/CMakeLists.txt
+++ b/tests/test_compile_headers_as_c11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(test_compile_headers_as_c11 C)
 
 set(CMAKE_C_STANDARD 11)

--- a/tests/test_compile_headers_as_c99/CMakeLists.txt
+++ b/tests/test_compile_headers_as_c99/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(test_compile_headers_as_c99 C)
 
 set(CMAKE_C_STANDARD 99)

--- a/tests/test_compile_headers_as_cpp/CMakeLists.txt
+++ b/tests/test_compile_headers_as_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(test_compile_headers_as_cpp CXX)
 
 add_executable(test_compile_headers_as_cpp


### PR DESCRIPTION
This stops errors about 3.5 compat when using CMake 4.0+

3.10 was picked because they're planning to deprecate versions below it soon too.